### PR TITLE
added tag disabling

### DIFF
--- a/src/main/java/j2html/tags/ContainerTag.java
+++ b/src/main/java/j2html/tags/ContainerTag.java
@@ -92,6 +92,10 @@ public class ContainerTag extends Tag<ContainerTag> {
      */
     @Override
     public String render() {
+        if (isDisabled()) {
+            return "";
+        }
+
         StringBuilder rendered = new StringBuilder(renderOpenTag());
         if (children != null && children.size() > 0) {
             for (DomContent child : children) {

--- a/src/main/java/j2html/tags/DisabledTag.java
+++ b/src/main/java/j2html/tags/DisabledTag.java
@@ -1,0 +1,12 @@
+package j2html.tags;
+
+public class DisabledTag extends Tag<DisabledTag> {
+    public DisabledTag() {
+        super(null);
+    }
+
+    @Override
+    public String render() {
+        return "";
+    }
+}

--- a/src/main/java/j2html/tags/EmptyTag.java
+++ b/src/main/java/j2html/tags/EmptyTag.java
@@ -8,6 +8,10 @@ public class EmptyTag extends Tag<EmptyTag> {
 
     @Override
     public String render() {
+        if (isDisabled()) {
+            return "";
+        }
+
         return renderOpenTag();
     }
 

--- a/src/main/java/j2html/tags/Tag.java
+++ b/src/main/java/j2html/tags/Tag.java
@@ -7,6 +7,7 @@ public abstract class Tag<T> extends DomContent {
 
     protected String tagName;
     private ArrayList<Attribute> attributes;
+    private boolean disabled;
 
     protected Tag(String tagName) {
         this.tagName = tagName;
@@ -14,6 +15,10 @@ public abstract class Tag<T> extends DomContent {
     }
 
     String renderOpenTag() {
+        if (disabled) {
+            return "";
+        }
+
         String tagAttributes = "";
         for (Attribute attribute : attributes) {
             tagAttributes += attribute.render();
@@ -22,6 +27,11 @@ public abstract class Tag<T> extends DomContent {
     }
 
     String renderCloseTag() {
+        if (disabled) {
+            return "";
+        }
+
+
         return "</" + tagName + ">";
     }
 
@@ -62,6 +72,15 @@ public abstract class Tag<T> extends DomContent {
      */
     public T condAttr(boolean condition, String attribute, String value) {
         return (condition ? attr(attribute, value) : (T) this);
+    }
+
+    public boolean isDisabled() {
+        return disabled;
+    }
+
+    public T disabled(boolean disabled) {
+        this.disabled = disabled;
+        return (T) this;
     }
 
     /**

--- a/src/test/java/j2html/tags/DisabledTagTest.java
+++ b/src/test/java/j2html/tags/DisabledTagTest.java
@@ -1,0 +1,13 @@
+package j2html.tags;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DisabledTagTest {
+    @Test
+    public void testDisabledTag() throws Exception {
+        DisabledTag tag = new DisabledTag();
+        assertEquals(tag.render(), "");
+    }
+}

--- a/src/test/java/j2html/tags/TagTest.java
+++ b/src/test/java/j2html/tags/TagTest.java
@@ -34,4 +34,15 @@ public class TagTest {
         assertEquals(testTag.renderCloseTag(), "</a>");
     }
 
+    @Test
+    public void testVisible() throws Exception {
+        ContainerTag testTag = new ContainerTag("div");
+        assertEquals(testTag.render(), "<div></div>");
+    }
+
+    @Test
+    public void testNotVisible() throws Exception {
+        ContainerTag testTag = new ContainerTag("div").disabled(true);
+        assertEquals(testTag.render(), "");
+    }
 }

--- a/src/test/java/j2html/tags/TagTest.java
+++ b/src/test/java/j2html/tags/TagTest.java
@@ -35,14 +35,26 @@ public class TagTest {
     }
 
     @Test
-    public void testVisible() throws Exception {
+    public void testNotDisabled() throws Exception {
         ContainerTag testTag = new ContainerTag("div");
         assertEquals(testTag.render(), "<div></div>");
     }
 
     @Test
-    public void testNotVisible() throws Exception {
+    public void testDisabled() throws Exception {
         ContainerTag testTag = new ContainerTag("div").disabled(true);
+        assertEquals(testTag.render(), "");
+    }
+
+    @Test
+    public void testDisabledWithNullBodyText() throws Exception {
+        ContainerTag testTag = new ContainerTag("title").withText(null).disabled(true);
+        assertEquals(testTag.render(), "");
+    }
+
+    @Test
+    public void testDisabledWithBody() throws Exception {
+        ContainerTag testTag = new ContainerTag("title").disabled(true).with(new ContainerTag("br"));
         assertEquals(testTag.render(), "");
     }
 }


### PR DESCRIPTION
Allows tags (including body) to be disabled from rendering. Example:
```
html().with(
	head().with(
		title(entity.getName()).disabled(entity.getName() == null)
	)
)
````