### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/src/main/java/j2html/TagCreator.java
+++ b/src/main/java/j2html/TagCreator.java
@@ -3,6 +3,8 @@ package j2html;
 import j2html.tags.*;
 
 public class TagCreator {
+    
+    private TagCreator() {}
 
     //Special tags
     public static ContainerTag tag(String tagName)          { return new ContainerTag(tagName); }

--- a/src/main/java/j2html/attributes/Attr.java
+++ b/src/main/java/j2html/attributes/Attr.java
@@ -1,6 +1,9 @@
 package j2html.attributes;
 
 public class Attr {
+    
+    private Attr() {}
+    
     public static String HIDDEN = "hidden";
     public static String HIGH = "high";
     public static String HREF = "href";

--- a/src/main/java/j2html/utils/CSSMin.java
+++ b/src/main/java/j2html/utils/CSSMin.java
@@ -59,6 +59,8 @@ import java.util.logging.*;
 import java.util.regex.*;
 
 public class CSSMin {
+    
+    private CSSMin() {}
 
     private static final Logger LOG = Logger.getLogger(CSSMin.class.getName());
 

--- a/src/main/java/j2html/utils/JSMin.java
+++ b/src/main/java/j2html/utils/JSMin.java
@@ -4,6 +4,8 @@ import com.google.javascript.jscomp.*;
 import com.google.javascript.jscomp.Compiler;
 
 public class JSMin {
+    
+    private JSMin() {}
 
     public static String compressJs(String code, String sourcePath) {
         com.google.javascript.jscomp.Compiler compiler = new Compiler();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed