### PR TITLE
created render(Appendable)-method

### DIFF
--- a/src/main/java/j2html/tags/ContainerTag.java
+++ b/src/main/java/j2html/tags/ContainerTag.java
@@ -1,6 +1,7 @@
 package j2html.tags;
 
 import java.util.*;
+import java.io.IOException;
 
 public class ContainerTag extends Tag<ContainerTag> {
 
@@ -100,6 +101,17 @@ public class ContainerTag extends Tag<ContainerTag> {
         }
         rendered.append(renderCloseTag());
         return rendered.toString();
+    }
+    
+    @Override
+    public void render(Appendable writer) throws IOException {
+        writer.append(renderOpenTag());
+        if (children != null && !children.isEmpty()) {
+            for (DomContent child : children) {
+                child.render(writer);
+            }
+        }
+        writer.append(renderCloseTag());
     }
 
 }

--- a/src/main/java/j2html/tags/DomContent.java
+++ b/src/main/java/j2html/tags/DomContent.java
@@ -1,8 +1,14 @@
 package j2html.tags;
 
+import java.io.IOException;
+
 public abstract class DomContent {
 
     public abstract String render();
+    
+    public void render(Appendable writer) throws IOException {
+        writer.append(render());
+    }
 
     @Override
     public String toString() {


### PR DESCRIPTION
The default implementation simply writes the result from render() in the appendable. This way most of the classes don't have to implement this method. ContainerTag passes the appendable to children so they can write their content. This way writing to sockets or files will be much faster.
