### PR TITLE
Adds method to add Attribute or Optional<Attribute> ifPresent

### DIFF
--- a/src/main/java/j2html/tags/Tag.java
+++ b/src/main/java/j2html/tags/Tag.java
@@ -1,6 +1,7 @@
 package j2html.tags;
 
 import java.util.ArrayList;
+import java.util.Optional;
 
 import j2html.attributes.Attr;
 import j2html.attributes.Attribute;
@@ -62,6 +63,42 @@ public abstract class Tag<T extends Tag<T>> extends DomContent {
         setAttribute(attribute, value);
         return (T) this;
     }
+    
+    
+    /**
+     * Sets a custom attribute
+     *
+     * @param attribute the attribute
+     * @return itself for easy chaining
+     */
+    public T attr(Attribute newAttribute) {
+        for (int i=0;i<attributes.size();i++){
+            Attribute attribute = attributes.get(i);
+            if (attribute.getName().equals(newAttribute.getName())) {
+                attributes.set(i, newAttribute); //update with new value
+                return (T) this;
+            }
+        }
+        attributes.add(newAttribute);
+        return (T) this;
+    }
+    
+    /**
+     * Sets a custom attribute if present
+     *
+     * @param attribute the attribute
+     * @return itself for easy chaining
+     */
+    public T attr(Optional<Attribute> newAttribute) {
+        if (newAttribute.isPresent()) {
+            return attr(newAttribute.get());
+        }
+        return (T) this;
+    }
+
+
+
+
 
 
     /**

--- a/src/test/java/j2html/tags/ConvenienceMethodTest.java
+++ b/src/test/java/j2html/tags/ConvenienceMethodTest.java
@@ -1,6 +1,10 @@
 package j2html.tags;
 
+import java.util.Optional;
+
 import org.junit.Test;
+
+import j2html.attributes.Attribute;
 
 import static j2html.TagCreator.a;
 import static j2html.TagCreator.div;
@@ -38,5 +42,7 @@ public class ConvenienceMethodTest {
         assertThat(img().withSrc("/img/test.png").render(), is("<img src=\"/img/test.png\">"));
         assertThat(div().withStyle("background:red;").render(), is("<div style=\"background:red;\"></div>"));
         assertThat(input().withValue("test-value").render(), is("<input value=\"test-value\">"));
+        assertThat(input().attr(new Attribute("test","test")).render(), is("<input test=\"test\">"));
+        assertThat(input().attr(Optional.of(new Attribute("test","test"))).render(), is("<input test=\"test\">"));
     }
 }


### PR DESCRIPTION
This is a simple addition of two methods to the Tag, to allow adding attributes as objects and one convience method to add an Optional<Attribute>. 

For the second method I would like to add such a type of method for in the style of condWith.
So maybe the the method `attr(Optional<Attribute> attr)` should have a different name e.g. 
`optAttr(Optional<Attribute> attr)`