### PR TITLE
java 6 support: removed diamond operators, apply version in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                     <optimize>true</optimize>
                 </configuration>
             </plugin>
@@ -84,7 +84,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[1.7,)</version>
+                                    <version>[1.6,)</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>

--- a/src/main/java/j2html/tags/ContainerTag.java
+++ b/src/main/java/j2html/tags/ContainerTag.java
@@ -11,7 +11,7 @@ public class ContainerTag extends Tag {
 
     public ContainerTag(String tagType) {
         super(tagType);
-        this.children = new ArrayList<>();
+        this.children = new ArrayList<Tag>();
     }
 
     /**

--- a/src/main/java/j2html/tags/Tag.java
+++ b/src/main/java/j2html/tags/Tag.java
@@ -12,7 +12,7 @@ public abstract class Tag {
 
     protected Tag(String tagType) {
         this.tag = tagType;
-        this.attributes = new ArrayList<>();
+        this.attributes = new ArrayList<Attribute>();
     }
 
     public void setParent(Tag parent) {

--- a/src/main/java/j2html/utils/CSSMin.java
+++ b/src/main/java/j2html/utils/CSSMin.java
@@ -112,7 +112,7 @@ public class CSSMin {
             if (debugLogging) {
                 LOG.info("Parsing and processing selectors...");
             }
-            Vector<Selector> selectors = new Vector<>();
+            Vector<Selector> selectors = new Vector<Selector>();
             n = 0;
             j = 0;
             for (int i = 0; i < sb.length(); i++) {
@@ -192,7 +192,7 @@ class Selector {
 
         // We're dealing with a nested property, eg @-webkit-keyframes
         if (parts.length > 2) {
-            this.subSelectors = new Vector<>();
+            this.subSelectors = new Vector<Selector>();
             parts = selector.split("(\\s*\\{\\s*)|(\\s*\\}\\s*)");
             for (int i = 1; i < parts.length; i += 2) {
                 parts[i] = parts[i].trim();
@@ -253,7 +253,7 @@ class Selector {
      * @return An array of properties parsed from this selector.
      */
     private ArrayList<Property> parseProperties(String contents) {
-        ArrayList<String> parts = new ArrayList<>();
+        ArrayList<String> parts = new ArrayList<String>();
         boolean bInsideString = false,
                 bInsideURL = false;
         int j = 0;
@@ -276,7 +276,7 @@ class Selector {
         substr = contents.substring(j, contents.length());
         if (!(substr.trim().equals(""))) parts.add(substr);
 
-        ArrayList<Property> results = new ArrayList<>();
+        ArrayList<Property> results = new ArrayList<Property>();
         for (String part : parts) {
             try {
                 results.add(new Property(part));
@@ -314,7 +314,7 @@ class Property implements Comparable<Property> {
     public Property(String property) throws IncompletePropertyException {
         try {
             // Parse the property.
-            ArrayList<String> parts = new ArrayList<>();
+            ArrayList<String> parts = new ArrayList<String>();
             boolean bCanSplit = true;
             int j = 0;
             String substr;


### PR DESCRIPTION
Please create a release to support JDK 6 as well.
Actually I would not like you to merge this to master, but I could not specify formally / don't have any other way to tell you that I would like to have a separate release (tag) that supports JDK 6.