### PR TITLE
Empty attribute

### DIFF
--- a/src/main/java/j2html/tags/Tag.java
+++ b/src/main/java/j2html/tags/Tag.java
@@ -65,6 +65,17 @@ public abstract class Tag<T extends Tag<T>> extends DomContent {
         return (T) this;
     }
 
+    /**
+     * Sets a custom attribute without value
+     *
+     * @param attribute the attribute name
+     * @return itself for easy chaining
+     * @see Tag#attr(String, String)
+     */
+    public T attr(String attribute) {
+        return attr(attribute, null);
+    }
+
 
     /**
      * Call attr-method based on condition

--- a/src/test/java/j2html/tags/TagTest.java
+++ b/src/test/java/j2html/tags/TagTest.java
@@ -58,5 +58,14 @@ public class TagTest {
         assertThat(actual, is(expected));
     }
 
+    @Test
+    public void testEmptyAttribute() throws Exception {
+        ContainerTag testTagWithAttrValueNull = new ContainerTag("a").attr("attribute", null);
+        assertThat(testTagWithAttrValueNull.render(), is("<a attribute></a>"));
+
+        ContainerTag testTagAttrWithoutAttr = new ContainerTag("a").attr("attribute");
+        assertThat(testTagAttrWithoutAttr.render(), is("<a attribute></a>"));
+    }
+
 
 }


### PR DESCRIPTION
Add a method to create attribute inside a tag without passing the key word null