### PR TITLE
Add extension point to use user provided text escaping

### DIFF
--- a/src/main/java/j2html/attributes/Attribute.java
+++ b/src/main/java/j2html/attributes/Attribute.java
@@ -1,7 +1,7 @@
 package j2html.attributes;
 
 
-import j2html.utils.SimpleEscaper;
+import j2html.utils.TextEscaperFactory;
 
 public class Attribute {
     private String name;
@@ -9,7 +9,7 @@ public class Attribute {
 
     public Attribute(String name, String value) {
         this.name = name;
-        this.value = SimpleEscaper.escape(value);
+        this.value = TextEscaperFactory.getInstance().escape(value);
     }
 
     public Attribute(String name) {

--- a/src/main/java/j2html/tags/Text.java
+++ b/src/main/java/j2html/tags/Text.java
@@ -1,6 +1,6 @@
 package j2html.tags;
 
-import j2html.utils.SimpleEscaper;
+import j2html.utils.TextEscaperFactory;
 
 public class Text extends DomContent {
 
@@ -12,7 +12,7 @@ public class Text extends DomContent {
 
     @Override
     public String render() {
-        return SimpleEscaper.escape(text);
+        return TextEscaperFactory.getInstance().escape(text);
     }
 
 }

--- a/src/main/java/j2html/utils/SimpleEscaper.java
+++ b/src/main/java/j2html/utils/SimpleEscaper.java
@@ -1,8 +1,9 @@
 package j2html.utils;
 
-public class SimpleEscaper {
+public class SimpleEscaper implements TextEscaper {
 
-    public static String escape(String s) {
+    @Override
+    public String escape(String s) {
         if (s == null) {
             return null;
         }
@@ -31,6 +32,11 @@ public class SimpleEscaper {
             }
         }
         return escapedText.toString();
+    }
+
+    @Override
+    public int getPriority() {
+        return Integer.MIN_VALUE;
     }
 
 }

--- a/src/main/java/j2html/utils/TextEscaper.java
+++ b/src/main/java/j2html/utils/TextEscaper.java
@@ -1,0 +1,9 @@
+package j2html.utils;
+
+public interface TextEscaper {
+
+    String escape(String text);
+
+    int getPriority();
+
+}

--- a/src/main/java/j2html/utils/TextEscaperFactory.java
+++ b/src/main/java/j2html/utils/TextEscaperFactory.java
@@ -1,0 +1,25 @@
+package j2html.utils;
+
+import java.util.ServiceLoader;
+
+public class TextEscaperFactory {
+
+    private static final TextEscaper INSTANCE;
+
+    static {
+        TextEscaper current = new SimpleEscaper();
+
+        for (TextEscaper escaper : ServiceLoader.load(TextEscaper.class)) {
+            if (escaper.getPriority() > current.getPriority()) {
+                current = escaper;
+            }
+        }
+
+        INSTANCE = current;
+    }
+
+    public static TextEscaper getInstance() {
+        return INSTANCE;
+    }
+
+}

--- a/src/main/resources/META-INF/services/j2html.utils.TextEscaper
+++ b/src/main/resources/META-INF/services/j2html.utils.TextEscaper
@@ -1,0 +1,1 @@
+j2html.utils.SimpleEscaper

--- a/src/test/java/j2html/PerformanceTest.java
+++ b/src/test/java/j2html/PerformanceTest.java
@@ -30,8 +30,8 @@ public class PerformanceTest {
 
     @Test
     public void test_escaper_performnce() throws Exception {
-        timeEscaper("SimpleEscaper#short", () -> SimpleEscaper.escape(shortTestString));
-        timeEscaper("SimpleEscaper#long", () -> SimpleEscaper.escape(longTestString));
+        timeEscaper("SimpleEscaper#short", () -> new SimpleEscaper().escape(shortTestString));
+        timeEscaper("SimpleEscaper#long", () -> new SimpleEscaper().escape(longTestString));
         timeEscaper("ApacheEscaper#short", () -> StringEscapeUtils.escapeHtml4(shortTestString));
         timeEscaper("ApacheEscaper#long", () -> StringEscapeUtils.escapeHtml4(longTestString));
     }


### PR DESCRIPTION
This pull request adds ability for user to provide another implementation of text escaping.

To do so you need to implement `TextEscaper` interface, create `META-INF/services/j2html.utils.TextEscaper` file and put fully qualified name of implementation into it.

`getPriority()` method should return any value bigger than `Integer.MIN_VALUE` to get priority over default implementation.