### PR TITLE
Add ability to change text escaper implementation

### DIFF
--- a/src/main/java/j2html/Config.java
+++ b/src/main/java/j2html/Config.java
@@ -1,0 +1,13 @@
+package j2html;
+
+import j2html.utils.SimpleEscaper;
+import j2html.utils.TextEscaper;
+
+public class Config {
+
+    private Config() {
+    }
+
+    public static TextEscaper textEscaper = new SimpleEscaper();
+
+}

--- a/src/main/java/j2html/attributes/Attribute.java
+++ b/src/main/java/j2html/attributes/Attribute.java
@@ -1,7 +1,7 @@
 package j2html.attributes;
 
 
-import j2html.utils.SimpleEscaper;
+import j2html.Config;
 
 public class Attribute {
     private String name;
@@ -9,7 +9,7 @@ public class Attribute {
 
     public Attribute(String name, String value) {
         this.name = name;
-        this.value = SimpleEscaper.escape(value);
+        this.value = Config.textEscaper.escape(value);
     }
 
     public Attribute(String name) {

--- a/src/main/java/j2html/tags/Text.java
+++ b/src/main/java/j2html/tags/Text.java
@@ -1,6 +1,6 @@
 package j2html.tags;
 
-import j2html.utils.SimpleEscaper;
+import j2html.Config;
 
 public class Text extends DomContent {
 
@@ -12,7 +12,7 @@ public class Text extends DomContent {
 
     @Override
     public String render() {
-        return SimpleEscaper.escape(text);
+        return Config.textEscaper.escape(text);
     }
 
 }

--- a/src/main/java/j2html/utils/SimpleEscaper.java
+++ b/src/main/java/j2html/utils/SimpleEscaper.java
@@ -1,8 +1,8 @@
 package j2html.utils;
 
-public class SimpleEscaper {
+public class SimpleEscaper implements TextEscaper {
 
-    public static String escape(String s) {
+    public String escape(String s) {
         if (s == null) {
             return null;
         }

--- a/src/main/java/j2html/utils/TextEscaper.java
+++ b/src/main/java/j2html/utils/TextEscaper.java
@@ -1,0 +1,7 @@
+package j2html.utils;
+
+public interface TextEscaper {
+
+    String escape(String text);
+
+}

--- a/src/test/java/j2html/PerformanceTest.java
+++ b/src/test/java/j2html/PerformanceTest.java
@@ -30,8 +30,8 @@ public class PerformanceTest {
 
     @Test
     public void test_escaper_performnce() throws Exception {
-        timeEscaper("SimpleEscaper#short", () -> SimpleEscaper.escape(shortTestString));
-        timeEscaper("SimpleEscaper#long", () -> SimpleEscaper.escape(longTestString));
+        timeEscaper("SimpleEscaper#short", () -> new SimpleEscaper().escape(shortTestString));
+        timeEscaper("SimpleEscaper#long", () -> new SimpleEscaper().escape(longTestString));
         timeEscaper("ApacheEscaper#short", () -> StringEscapeUtils.escapeHtml4(shortTestString));
         timeEscaper("ApacheEscaper#long", () -> StringEscapeUtils.escapeHtml4(longTestString));
     }

--- a/src/test/java/j2html/TextEscaperTest.java
+++ b/src/test/java/j2html/TextEscaperTest.java
@@ -1,0 +1,40 @@
+package j2html;
+
+import j2html.utils.SimpleEscaper;
+import j2html.utils.TextEscaper;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+public class TextEscaperTest {
+
+    @Test
+    public void testTextEscaper() throws Exception  {
+        assertThat("default text escaper is SimpleEscaper",
+                Config.textEscaper, is(instanceOf(SimpleEscaper.class)));
+
+        String expected = "&lt;div&gt;&lt;/div&gt;";
+        assertThat("default text escaper works",
+                Config.textEscaper.escape("<div></div>"), is(expected));
+
+        Config.textEscaper = new NoOpEscaper();
+        assertThat("user can change text escaper implementation",
+                Config.textEscaper, is(instanceOf(NoOpEscaper.class)));
+
+        expected = "<div></div>";
+        assertThat("user provided text escaper actually works",
+                Config.textEscaper.escape("<div></div>"), is(expected));
+    }
+
+    private static class NoOpEscaper implements TextEscaper {
+
+        @Override
+        public String escape(String text) {
+            return text;
+        }
+
+    }
+
+}


### PR DESCRIPTION
Based on discussion in #69, this pull request adds ability for user to provide another implementation of text escaping.

To do so you can either implement `TextEscaper` interface or use lambda expression and assign it to `Config.textEscaper`.