### PR TITLE
Overloaded method of iff for java8 Optional<>'s. (Includes test)

### DIFF
--- a/src/main/java/j2html/TagCreator.java
+++ b/src/main/java/j2html/TagCreator.java
@@ -10,6 +10,8 @@ import j2html.tags.Text;
 import j2html.tags.UnescapedText;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -29,6 +31,23 @@ public class TagCreator {
      */
     public static <T> T iff(boolean condition, T ifValue) {
         return condition ? ifValue : null;
+    }
+    
+    /**
+     * Generic if-expression to if'ing inside method calls
+     *
+     * @param optional   The item that may be present
+     * @param ifFunction The function that will be called if that optional is present
+     * @param <T>        The derived generic parameter type
+     * @param <U>        The supplying generic parameter type
+     * @return transformed value if condition is true, null otherwise
+     */
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    public static <T, U> T iff(Optional<U> optional, Function<U, T> ifFunction) {
+        if (Objects.nonNull(optional) && optional.isPresent()) {
+            return optional.map(ifFunction).orElse(null);
+        }
+        return null;
     }
 
     /**

--- a/src/test/java/j2html/tags/TagCreatorTest.java
+++ b/src/test/java/j2html/tags/TagCreatorTest.java
@@ -3,6 +3,7 @@ package j2html.tags;
 import j2html.Config;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -35,6 +36,17 @@ public class TagCreatorTest {
             p("Test"),
             iff(1 == 1, a("Test").withHref("#")),
             iff(1 == 2, a("Tast").withHref("#"))
+        ).render();
+        assertThat(actual, is(expected));
+    }
+    
+    @Test
+    public void testIffOptional() {
+        String expected = "<div><p>Test</p><a href=\"#1\">Test</a></div>";
+        String actual = div(
+            p("Test"),
+            iff(Optional.of(1), i -> a("Test").withHref("#" + i)),
+            iff(Optional.empty(), i -> a("Tast").withHref("#2"))
         ).render();
         assertThat(actual, is(expected));
     }


### PR DESCRIPTION
Using an optional as a condition is really tricky. Even if the optional is not present, the right value of ifValue must be evaluated eagerly in order to be passed to the method. Passing a lambda function for ifFunction allows the value to be evaluated lazily. This avoids the need to manually map and "elseGet" a null value to preserve current functionality.