### PR TITLE
Add Stream<DomContent> variants of each and with

### DIFF
--- a/src/main/java/j2html/TagCreator.java
+++ b/src/main/java/j2html/TagCreator.java
@@ -18,6 +18,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class TagCreator {
 
@@ -84,6 +85,17 @@ public class TagCreator {
     }
 
     /**
+     * Creates a DomContent object containing HTML elements from a stream.
+     * Intended usage: {@literal each(numbers.stream().map(n -> li(n.toString())))}
+     *
+     * @param stream the stream of DomContent elements
+     * @return DomContent containing elements from the stream
+     */
+    public static DomContent each(Stream<DomContent> stream) {
+        return new ContainerTag(null).with(stream);
+    }
+
+    /**
      * Creates a DomContent object containing HTML using a mapping function on a collection
      * Intended usage: {@literal each(numbers, n -> li(n.toString()))}
      *
@@ -93,7 +105,7 @@ public class TagCreator {
      * @return DomContent containing mapped data {@literal (ex. docs: [li(1), li(2), li(3)])}
      */
     public static <T> DomContent each(Collection<T> collection, Function<? super T, DomContent> mapper) {
-        return tag(null).with(collection.stream().map(mapper).collect(Collectors.toList()));
+        return tag(null).with(collection.stream().map(mapper));
     }
 
     public static <I, T> DomContent each(final Map<I, T> map, final Function<Entry<I, T>, DomContent> mapper) {

--- a/src/main/java/j2html/tags/ContainerTag.java
+++ b/src/main/java/j2html/tags/ContainerTag.java
@@ -4,6 +4,7 @@ import j2html.Config;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 public class ContainerTag extends Tag<ContainerTag> {
 
@@ -85,6 +86,18 @@ public class ContainerTag extends Tag<ContainerTag> {
         for (DomContent child : children) {
             with(child);
         }
+        return this;
+    }
+
+
+    /**
+     * Appends the DomContent-objects in the stream to the end of this element
+     *
+     * @param children Stream of DomContent-objects to be appended
+     * @return itself for easy chaining
+     */
+    public ContainerTag with(Stream<DomContent> children) {
+        children.forEach(this::with);
         return this;
     }
 

--- a/src/test/java/j2html/tags/TagCreatorTest.java
+++ b/src/test/java/j2html/tags/TagCreatorTest.java
@@ -144,6 +144,16 @@ public class TagCreatorTest {
     }
 
     @Test
+    public void testEachWithStream() throws Exception {
+        final String j2htmlMap = ul().with(
+            li("Begin list"),
+            each(employeeMap.entrySet().stream().map(e -> li(e.getKey() + "-" + e.getValue().name)))
+        ).render();
+
+        assertThat(j2htmlMap, is("<ul><li>Begin list</li><li>1-Name 1</li><li>2-Name 2</li><li>3-Name 3</li></ul>"));
+    }
+
+    @Test
     public void testAllTags() throws Exception {
 
         //Special Tags


### PR DESCRIPTION
The each-methods that takes a Collection or a Map and a Function or BiFunction are nice, but accepting Stream<DomContent> directly would be even more powerful.

    each(filter(numbers, n -> n % 2 == 0), n -> li(n.toString()))

would become

    each(numbers.stream().filter(n -> n % 2 == 0).map(n -> li(n.toString())))

Sure, that's not shorter but it means other stream functionality such as limit, flatMap, etc. won't have to be duplicated as TagCreator methods. E.g.:

    each(numbers.stream().filter(n -> n % 2 == 0).limit(10).map(n -> li(n.toString())))