### PR TITLE
Generate tags from JSON file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,21 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.7</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.5</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup</groupId>
+            <artifactId>javapoet</artifactId>
+            <version>1.11.1</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
@@ -50,12 +65,6 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
             <version>1.3</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/j2html/tags/TagCreatorCodeGeneratorFromJson.java
+++ b/src/main/java/j2html/tags/TagCreatorCodeGeneratorFromJson.java
@@ -1,0 +1,78 @@
+package j2html.tags;
+
+import com.google.gson.*;
+import com.squareup.javapoet.*;
+import j2html.attributes.Attr;
+
+import javax.lang.model.element.Modifier;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.StringWriter;
+
+import static org.apache.commons.lang3.StringUtils.capitalize;
+
+public class TagCreatorCodeGeneratorFromJson {
+
+    public static void main(String[] args) throws Exception {
+        StringWriter output = new StringWriter();
+
+        try (FileReader fileReader = new FileReader("src/main/resources/tagClasses.json")) {
+            JsonObject json = new Gson().fromJson(fileReader, JsonObject.class);
+            ClassName containerTagClassName = ClassName.get(ContainerTag.class);
+            json.getAsJsonArray("tags").forEach(element -> {
+                JsonObject tagJson = element.getAsJsonObject();
+
+                String tag = tagJson.get("tag").getAsString();
+                ClassName tagClassName = ClassName.get("j2html.tags", capitalize(tag + "Tag"));
+                TypeSpec.Builder typeSpec = TypeSpec.classBuilder(tagClassName)
+                    .superclass(ParameterizedTypeName.get(containerTagClassName, tagClassName))
+                    .addMethod(
+                        MethodSpec.constructorBuilder()
+                            .addModifiers(Modifier.PUBLIC)
+                            .addStatement("super(\"" + tag + "\")")
+                            .build());
+
+                JsonArray attrs = tagJson.getAsJsonArray("attrs");
+                attrs.forEach(attrElement -> {
+                    String attrName = attrElement.isJsonObject() ? attrElement.getAsJsonObject().get("name").getAsString() : attrElement.getAsString();
+                    String attrNameCapitalized = capitalize(attrName);
+
+                    MethodSpec.Builder methodSpec = MethodSpec.methodBuilder("with" + attrNameCapitalized)
+                        .addModifiers(Modifier.PUBLIC)
+                        .returns(tagClassName);
+
+                    MethodSpec.Builder condMethodSpec = MethodSpec.methodBuilder("withCond" + attrNameCapitalized)
+                        .addModifiers(Modifier.PUBLIC)
+                        .addParameter(boolean.class, "condition")
+                        .returns(tagClassName);
+
+                    if (attrElement.isJsonObject() && new JsonPrimitive(true).equals(attrElement.getAsJsonObject().get("empty"))) {
+                        methodSpec.addStatement("return attr(\"" + attrName + "\")");
+                        condMethodSpec.addStatement("return condAttr(condition, \"" + attrName + "\", \"" + attrName + "\")");
+                    } else {
+                        methodSpec
+                            .addParameter(String.class, attrName)
+                            .addStatement("return attr(\"" + attrName + "\", " + attrName + ")");
+                        condMethodSpec
+                            .addParameter(boolean.class, "condition")
+                            .addParameter(String.class, attrName)
+                            .addStatement("return condAttr(condition, \"" + attrName + "\", " + attrName + ")");
+                    }
+                    typeSpec.addMethod(methodSpec.build())
+                        .addMethod(condMethodSpec.build());
+                });
+
+                try {
+                    JavaFile.builder("j2html.tags", typeSpec.build())
+                        .build()
+                        .writeTo(output);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+
+        System.out.println(output);
+    }
+}

--- a/src/main/resources/tagClasses.json
+++ b/src/main/resources/tagClasses.json
@@ -1,0 +1,17 @@
+{
+    "tags": [
+        {
+            "tag": "a",
+            "attrs": [
+                "href",
+                "charset"
+            ]
+        },
+        {
+            "tag": "video",
+            "attrs": [
+                { "name": "autoplay", "empty": true }, "controls", "height", "loop", "muted", "poster", "preload", "src", "width"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Inspired by @mkopylec and #117 , here is a slightly different approach.

The way I see it, the generator would be in a maven plugin, so that the resulting code would be in the generated source folder and no-one would try to edit it.

The project itself would contain the configuration file (in this POC, it's JSON). This makes it easy to add tags and attributes, and also to customise the methods. For example, I used an "empty" field to output methods that don't take a value. Here's an example of the two kinds of output, where autoplay is empty and controls is not:

![image](https://user-images.githubusercontent.com/58760/42035958-6d5a3b22-7ae4-11e8-8ed0-3d44b19701da.png)

Here's what the config file looks like:
```json
{
    "tags": [
        {
            "tag": "a",
            "attrs": [
                "href",
                "charset"
            ]
        },
        {
            "tag": "video",
            "attrs": [
                { "name": "autoplay", "empty": true },
                "controls", "height", "loop", "muted", "poster", "preload", "src", "width"
            ]
        }
    ]
}
```
