### PR TITLE
Add supplied versions of iff and iffElse.

### DIFF
--- a/src/main/java/j2html/TagCreator.java
+++ b/src/main/java/j2html/TagCreator.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -35,6 +36,18 @@ public class TagCreator {
      */
     public static <T> T iff(boolean condition, T ifValue) {
         return condition ? ifValue : null;
+    }
+
+     /**
+     * Generic if-expression to do if'ing inside method calls
+     *
+     * @param <T>        The derived generic parameter type
+     * @param condition  the condition to if-on
+     * @param ifSupplier the supplier to return a value from if condition is true
+     * @return value if condition is true, null otherwise
+     */
+    public static <T> T iff(boolean condition, Supplier<T> ifSupplier) {
+        return condition ? ifSupplier.get() : null;
     }
 
     /**
@@ -59,6 +72,14 @@ public class TagCreator {
      */
     public static <T> T iffElse(boolean condition, T ifValue, T elseValue) {
         return condition ? ifValue : elseValue;
+    }
+
+    /**
+     * Like {@link j2html.TagCreator#iff}, but returns else-value instead of null
+     */
+    public static <T> T iffElse(boolean condition, Supplier<T> ifSupplier,
+        Supplier<T> elseSupplier) {
+        return condition ? ifSupplier.get() : elseSupplier.get();
     }
 
     /**

--- a/src/test/java/j2html/tags/TagCreatorTest.java
+++ b/src/test/java/j2html/tags/TagCreatorTest.java
@@ -50,6 +50,17 @@ public class TagCreatorTest {
         ).render();
         assertThat(actual, is(expected));
     }
+
+    @Test
+    public void testIffSupplier() throws Exception {
+        String expected = "<div><p>Test</p><a href=\"#\">Test</a></div>";
+        String actual = div(
+            p("Test"),
+            iff(1 == 1, () -> a("Test").withHref("#")),
+            iff(1 == 2, () -> a("Tast").withHref("#"))
+        ).render();
+        assertThat(actual, is(expected));
+    }
     
     @Test
     public void testIffOptional() {
@@ -66,6 +77,16 @@ public class TagCreatorTest {
     public void testIffElse() throws Exception {
         String expected = "<div><p>Tast</p></div>";
         String actual = div(iffElse(1 == 2, p("Test"), p("Tast"))).render();
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void testIffElseSupplier() throws Exception {
+        String expected = "<div><p>Test</p><p>Tast</p></div>";
+        String actual = div(
+            iffElse(1 == 1, () -> p("Test"), () -> p("Tast")),
+            iffElse(1 == 2, () -> p("Test"), () -> p("Tast"))
+        ).render();
         assertThat(actual, is(expected));
     }
 


### PR DESCRIPTION
This allows the supplied value to be lazily evaluated. Therefore, it can avoid building a part of the page that never ends up being displayed, just like a regular if statement.

```
iff(!items.isEmpty(), () -> each(items, item -> ...)
```