### PR TITLE
remove private constructor

### DIFF
--- a/src/main/java/j2html/attributes/Attr.java
+++ b/src/main/java/j2html/attributes/Attr.java
@@ -114,8 +114,6 @@ public abstract class Attr {
     public static final String VALUE = "value";
     public static final String WIDTH = "width";
     public static final String WRAP = "wrap";
-    private Attr() {
-    }
 
     public static ShortForm shortFormFromAttrsString(String attrs) {
         if (!attrs.contains(".") && !attrs.contains(("#"))) {


### PR DESCRIPTION
Forgot to make Attr instantiable...

I could make a new class (say AttrBuilder) if you'd prefer Attr to remain non-instantiable.