### PR TITLE
bug-fix: Children of non-formatted tags

### DIFF
--- a/src/test/java/j2html/tags/RenderFormattedTest.java
+++ b/src/test/java/j2html/tags/RenderFormattedTest.java
@@ -6,6 +6,7 @@ import static j2html.TagCreator.each;
 import static j2html.TagCreator.li;
 import static j2html.TagCreator.p;
 import static j2html.TagCreator.pre;
+import static j2html.TagCreator.span;
 import static j2html.TagCreator.textarea;
 import static j2html.TagCreator.ul;
 import static java.util.Arrays.asList;
@@ -27,6 +28,17 @@ public class RenderFormattedTest {
             "    <pre>public void renderModel(Appendable writer, Object model) throws IOException {\n" +
             "        writer.append(text);\n" +
             "    }</pre>\n" +
+            "</div>\n"));
+    }
+
+    @Test
+    public void testFormattedTags_doesntFormatPreChildren() throws Exception {
+        assertThat(div(pre("public void renderModel(Appendable writer, Object model) throws IOException {\n" +
+            "        writer.append(text);\n" +
+            "    }").with(span("Test"))).renderFormatted(), is("<div>\n" +
+            "    <pre>public void renderModel(Appendable writer, Object model) throws IOException {\n" +
+            "        writer.append(text);\n" +
+            "    }<span>Test</span></pre>\n" +
             "</div>\n"));
     }
 


### PR DESCRIPTION
Resolves GH-138.

The output is now:
```html
<html>
    <head>
        <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js">
        </script>
        <style>
            pre.prettyprint {padding: 0; border: 0;}
        </style>
    </head>
    <body>
        <pre class="prettyprint lang-java">/*
 * Decompiled with CFR 0.141.
 */
package <span class="package">net.minecraftforge.api.distmarker</span>;

public enum Dist {
    <span class="field" data-parent="test">CLIENT</span>,
    <span class="field" data-parent="test">DEDICATED_SERVER</span>;
    

    public boolean isDedicatedServer() {
        return !this.isClient();
    }

    public boolean isClient() {
        return this == CLIENT;
    }
}
</pre>
    </body>
</html>
```