### PR TITLE
#145 override `toString` calling `render()` allowing inline usage

### DIFF
--- a/src/main/java/j2html/tags/DomContent.java
+++ b/src/main/java/j2html/tags/DomContent.java
@@ -1,4 +1,8 @@
 package j2html.tags;
 
 public abstract class DomContent implements Renderable {
+    @Override
+    public String toString() {
+        return render();
+    }
 }


### PR DESCRIPTION
```
String content = "Some content already generated";
content += tr(th("Name"),th("Desc")) + "some other content";
```