### PR TITLE
Inline script escapes single quotes (#149)

### DIFF
--- a/src/main/java/j2html/TagCreator.java
+++ b/src/main/java/j2html/TagCreator.java
@@ -2011,28 +2011,28 @@ public class TagCreator {
         return Attr.addTo(new ContainerTag("samp").with(dc), shortAttr);
     }
 
+    public static ContainerTag script(Attr.ShortForm shortAttr) {
+        return Attr.addTo(script(), shortAttr);
+    }
+
     public static ContainerTag script() {
         return new ContainerTag("script");
     }
 
+    public static ContainerTag script(Attr.ShortForm shortAttr, String text) {
+        return Attr.addTo(script(text), shortAttr);
+    }
+
     public static ContainerTag script(String text) {
-        return new ContainerTag("script").withText(text);
+        return new ContainerTag("script").with(new UnescapedText(text));
+    }
+
+    public static ContainerTag script(Attr.ShortForm shortAttr, DomContent... dc) {
+        return Attr.addTo(script(dc), shortAttr);
     }
 
     public static ContainerTag script(DomContent... dc) {
         return new ContainerTag("script").with(dc);
-    }
-
-    public static ContainerTag script(Attr.ShortForm shortAttr) {
-        return Attr.addTo(new ContainerTag("script"), shortAttr);
-    }
-
-    public static ContainerTag script(Attr.ShortForm shortAttr, String text) {
-        return Attr.addTo(new ContainerTag("script").withText(text), shortAttr);
-    }
-
-    public static ContainerTag script(Attr.ShortForm shortAttr, DomContent... dc) {
-        return Attr.addTo(new ContainerTag("script").with(dc), shortAttr);
     }
 
     public static ContainerTag section() {

--- a/src/test/java/j2html/tags/TagCreatorTest.java
+++ b/src/test/java/j2html/tags/TagCreatorTest.java
@@ -317,4 +317,11 @@ public class TagCreatorTest {
         assertThat(video().render(), is("<video></video>"));
     }
 
+    @Test
+    public void testScriptWithText() {
+        String expected = "<script>var test = 'Hello, world!';</script>";
+        String actual = script("var test = 'Hello, world!';").render();
+        assertEquals(expected, actual);
+    }
+
 }


### PR DESCRIPTION
TagCreator.script(String text) method has been using a Text object which is escaping. I placed UnescapedText instead and wrote a simple test.