### PR TITLE
#140 #149 Escaped JS, CSS

### DIFF
--- a/src/main/java/j2html/TagCreator.java
+++ b/src/main/java/j2html/TagCreator.java
@@ -2011,28 +2011,28 @@ public class TagCreator {
         return Attr.addTo(new ContainerTag("samp").with(dc), shortAttr);
     }
 
+    public static ContainerTag script(Attr.ShortForm shortAttr) {
+        return Attr.addTo(script(), shortAttr);
+    }
+
     public static ContainerTag script() {
         return new ContainerTag("script");
     }
 
+    public static ContainerTag script(Attr.ShortForm shortAttr, String text) {
+        return Attr.addTo(script(text), shortAttr);
+    }
+
     public static ContainerTag script(String text) {
-        return new ContainerTag("script").withText(text);
+        return new ContainerTag("script").with(new UnescapedText(text));
+    }
+
+    public static ContainerTag script(Attr.ShortForm shortAttr, DomContent... dc) {
+        return Attr.addTo(script(dc), shortAttr);
     }
 
     public static ContainerTag script(DomContent... dc) {
         return new ContainerTag("script").with(dc);
-    }
-
-    public static ContainerTag script(Attr.ShortForm shortAttr) {
-        return Attr.addTo(new ContainerTag("script"), shortAttr);
-    }
-
-    public static ContainerTag script(Attr.ShortForm shortAttr, String text) {
-        return Attr.addTo(new ContainerTag("script").withText(text), shortAttr);
-    }
-
-    public static ContainerTag script(Attr.ShortForm shortAttr, DomContent... dc) {
-        return Attr.addTo(new ContainerTag("script").with(dc), shortAttr);
     }
 
     public static ContainerTag section() {

--- a/src/main/java/j2html/TagCreator.java
+++ b/src/main/java/j2html/TagCreator.java
@@ -2011,20 +2011,12 @@ public class TagCreator {
         return Attr.addTo(new ContainerTag("samp").with(dc), shortAttr);
     }
 
-    public static ContainerTag script(Attr.ShortForm shortAttr) {
-        return Attr.addTo(script(), shortAttr);
-    }
-
-    public static ContainerTag script() {
-        return new ContainerTag("script");
-    }
-
     public static ContainerTag script(Attr.ShortForm shortAttr, String text) {
         return Attr.addTo(script(text), shortAttr);
     }
 
     public static ContainerTag script(String text) {
-        return new ContainerTag("script").with(new UnescapedText(text));
+        return script().with(new UnescapedText(text));
     }
 
     public static ContainerTag script(Attr.ShortForm shortAttr, DomContent... dc) {
@@ -2032,7 +2024,15 @@ public class TagCreator {
     }
 
     public static ContainerTag script(DomContent... dc) {
-        return new ContainerTag("script").with(dc);
+        return script().with(dc);
+    }
+
+    public static ContainerTag script(Attr.ShortForm shortAttr) {
+        return Attr.addTo(script(), shortAttr);
+    }
+
+    public static ContainerTag script() {
+        return new ContainerTag("script");
     }
 
     public static ContainerTag section() {
@@ -2155,28 +2155,28 @@ public class TagCreator {
         return Attr.addTo(new ContainerTag("strong").with(dc), shortAttr);
     }
 
-    public static ContainerTag style() {
-        return new ContainerTag("style");
+    public static ContainerTag style(Attr.ShortForm shortAttr, String text) {
+        return Attr.addTo(style(text), shortAttr);
     }
 
     public static ContainerTag style(String text) {
-        return new ContainerTag("style").withText(text);
-    }
-
-    public static ContainerTag style(DomContent... dc) {
-        return new ContainerTag("style").with(dc);
-    }
-
-    public static ContainerTag style(Attr.ShortForm shortAttr) {
-        return Attr.addTo(new ContainerTag("style"), shortAttr);
-    }
-
-    public static ContainerTag style(Attr.ShortForm shortAttr, String text) {
-        return Attr.addTo(new ContainerTag("style").withText(text), shortAttr);
+        return style().with(new UnescapedText(text));
     }
 
     public static ContainerTag style(Attr.ShortForm shortAttr, DomContent... dc) {
-        return Attr.addTo(new ContainerTag("style").with(dc), shortAttr);
+        return Attr.addTo(style(dc), shortAttr);
+    }
+
+    public static ContainerTag style(DomContent... dc) {
+        return style().with(dc);
+    }
+
+    public static ContainerTag style(Attr.ShortForm shortAttr) {
+        return Attr.addTo(style(), shortAttr);
+    }
+
+    public static ContainerTag style() {
+        return new ContainerTag("style");
     }
 
     public static ContainerTag sub() {

--- a/src/test/java/j2html/tags/TagCreatorTest.java
+++ b/src/test/java/j2html/tags/TagCreatorTest.java
@@ -324,4 +324,11 @@ public class TagCreatorTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    public void testStyleWithText() {
+        String expected = "<style>.test>a {}</style>";
+        String actual = style(".test>a {}").render();
+        assertEquals(expected, actual);
+    }
+
 }

--- a/src/test/java/j2html/tags/TagCreatorTest.java
+++ b/src/test/java/j2html/tags/TagCreatorTest.java
@@ -317,4 +317,11 @@ public class TagCreatorTest {
         assertThat(video().render(), is("<video></video>"));
     }
 
+    @Test
+    public void testScriptWithText() {
+        String expected = "<script>var test = 'Hello, world!';</script>";
+        String actual = script("var test = 'Hello, world!';").render();
+        assertEquals(expected, actual);
+    }
+
 }


### PR DESCRIPTION
Two methods TagCreator.script(String text) and TagCreator.style(String text) were using a Text-object which is escaping. I have placed UnescapedText-object instead and have written 2 simple tests.