### PR TITLE
lombok was almost never used. also gave me errors on 'mvn install' on…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,12 +72,6 @@
             <version>1.7</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.16.18</version>
-            <scope>test</scope>
-        </dependency>
 
     </dependencies>
 

--- a/src/test/java/j2html/comparison/model/Employee.java
+++ b/src/test/java/j2html/comparison/model/Employee.java
@@ -4,4 +4,22 @@ public class Employee {
     int id;
     String name;
     String title;
+
+    public Employee(int id, String name, String title) {
+        this.id = id;
+        this.name = name;
+        this.title = title;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getTitle() {
+        return title;
+    }
 }

--- a/src/test/java/j2html/comparison/model/Employee.java
+++ b/src/test/java/j2html/comparison/model/Employee.java
@@ -1,8 +1,5 @@
 package j2html.comparison.model;
 
-import lombok.Value;
-
-@Value
 public class Employee {
     int id;
     String name;


### PR DESCRIPTION
… ubuntu 20.04 https://github.com/rzwitserloot/lombok/issues/1651 . unless there are plans to use it more extensively, maybe it is best to remove it, to clean up the dependencies and enable me (and maybe others) to build without errors.

Summary:
`mvn install` gives me the mentioned error on ubuntu 20.04. removing lombok solved it for me. 
