### PR TITLE
Escape Attribute on render instead of in constructor. Fixes #160

### DIFF
--- a/src/main/java/j2html/attributes/Attribute.java
+++ b/src/main/java/j2html/attributes/Attribute.java
@@ -10,7 +10,7 @@ public class Attribute implements Renderable {
 
     public Attribute(String name, String value) {
         this.name = name;
-        this.value = Config.textEscaper.escape(value);
+        this.value = value;
     }
 
     public Attribute(String name) {
@@ -23,12 +23,12 @@ public class Attribute implements Renderable {
         if (name == null) {
             return;
         }
-        writer.append(" ");
+        writer.append(' ');
         writer.append(name);
         if (value != null) {
             writer.append("=\"");
-            writer.append(value);
-            writer.append("\"");
+            writer.append(Config.textEscaper.escape(value));
+            writer.append('"');
         }
     }
 

--- a/src/main/java/j2html/utils/EscapeUtil.java
+++ b/src/main/java/j2html/utils/EscapeUtil.java
@@ -6,7 +6,7 @@ public class EscapeUtil {
         if (s == null) {
             return null;
         }
-        StringBuilder escapedText = new StringBuilder();
+        StringBuilder escapedText = new StringBuilder(s.length()+16);
         char currentChar;
         for (int i = 0; i < s.length(); i++) {
             currentChar = s.charAt(i);


### PR DESCRIPTION
Also initialize EscapeUtil StringBuilder with input length to avoid growing copying.

#160 