### PR TITLE
Make join method work as expected

### DIFF
--- a/library/src/main/java/j2html/tags/DomContentJoiner.java
+++ b/library/src/main/java/j2html/tags/DomContentJoiner.java
@@ -4,15 +4,20 @@ public class DomContentJoiner {
 
     public static UnescapedText join(CharSequence delimiter, boolean fixPeriodAndCommaSpacing, Object... stringOrDomObjects) {
         StringBuilder sb = new StringBuilder();
-        for (Object o : stringOrDomObjects) {
+        for (int i = 0; i < stringOrDomObjects.length; i++) {
+            Object o = stringOrDomObjects[i];
             if (o instanceof String) {
-                sb.append(((String) o).trim()).append(delimiter);
+                sb.append(((String) o).trim());
             } else if (o instanceof DomContent) {
-                sb.append(((DomContent) o).render().trim()).append(delimiter);
+                sb.append(((DomContent) o).render().trim());
             } else if (o == null) {
                 //Discard null objects so iff/iffelse can be used with join
+                continue;
             } else {
                 throw new RuntimeException("You can only join DomContent and String objects");
+            }
+            if (i < stringOrDomObjects.length-1) {
+                sb.append(delimiter);
             }
         }
         String joined = sb.toString().trim();

--- a/library/src/main/java/j2html/tags/UnescapedText.java
+++ b/library/src/main/java/j2html/tags/UnescapedText.java
@@ -20,4 +20,11 @@ public class UnescapedText extends DomContent {
         writer.append(text);
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null || !(obj instanceof UnescapedText)) {
+            return false;
+        }
+        return ((UnescapedText) obj).render().equals(this.render());
+    }
 }

--- a/library/src/test/java/j2html/tags/DomContentJoinerTest.java
+++ b/library/src/test/java/j2html/tags/DomContentJoinerTest.java
@@ -1,0 +1,14 @@
+package j2html.tags;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class DomContentJoinerTest {
+    @Test
+    public void testJoin() {
+        assertThat(DomContentJoiner.join(",", true, "a", "b", "c"), is(new UnescapedText("a,b,c")));
+        assertThat(DomContentJoiner.join(",", false, "a", "b", "c"), is(new UnescapedText("a,b,c")));
+    }
+}


### PR DESCRIPTION
### Description
For this list: 
```java
List<String> list = List.of("a", "b", "c");
```

A normal join works like:
```java
System.out.println(String.join(", ", list));
// a, b, c
```

But this join works like:
```java
join(", ", true, list.stream().toArray())
// a, b, c,
```

This PR addresses the difference between joins listed previously:

See https://github.com/tipsy/j2html/issues/169

#### Please Review: @tipsy 
