### PR TITLE
Minor restructuring of Tag internals, increased argument validation, …

### DIFF
--- a/library/src/main/java/j2html/tags/ContainerTag.java
+++ b/library/src/main/java/j2html/tags/ContainerTag.java
@@ -1,13 +1,14 @@
 package j2html.tags;
 
 import j2html.Config;
+import j2html.attributes.Attribute;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
 public class ContainerTag<T extends ContainerTag<T>> extends Tag<T> {
-//public class ContainerTag extends Tag<ContainerTag> {
 
     private List<DomContent> children;
 
@@ -209,6 +210,26 @@ public class ContainerTag<T extends ContainerTag<T>> extends Tag<T> {
         return "textarea".equals(tagName) || "pre".equals(tagName);
     }
 
+    protected void renderOpenTag(Appendable writer, Object model) throws IOException {
+        if (!hasTagName()) { // avoid <null> and <> tags
+            return;
+        }
+        writer.append("<").append(tagName);
+        for (Attribute attribute : getAttributes()) {
+            attribute.renderModel(writer, model);
+        }
+        writer.append(">");
+    }
+
+    protected void renderCloseTag(Appendable writer) throws IOException {
+        if (!hasTagName()) { // avoid <null> and <> tags
+            return;
+        }
+        writer.append("</");
+        writer.append(tagName);
+        writer.append(">");
+    }
+
     @Override
     public void renderModel(Appendable writer, Object model) throws IOException {
         renderOpenTag(writer, model);
@@ -219,12 +240,4 @@ public class ContainerTag<T extends ContainerTag<T>> extends Tag<T> {
         }
         renderCloseTag(writer);
     }
-
-    @FunctionalInterface
-    private interface ThrowingBiFunction<T, U, R, E extends Exception> {
-
-        R apply(final T t, final U u) throws E;
-
-    }
-
 }

--- a/library/src/main/java/j2html/tags/EmptyTag.java
+++ b/library/src/main/java/j2html/tags/EmptyTag.java
@@ -5,10 +5,15 @@ import j2html.attributes.Attribute;
 import java.io.IOException;
 
 public class EmptyTag<T extends EmptyTag<T>> extends Tag<T> {
-//public class EmptyTag extends Tag<EmptyTag> {
 
     public EmptyTag(String tagName) {
         super(tagName);
+        if(tagName == null){
+            throw new IllegalArgumentException("Illegal tag name: null");
+        }
+        if("".equals(tagName)){
+            throw new IllegalArgumentException("Illegal tag name: \"\"");
+        }
     }
 
     @Override

--- a/library/src/main/java/j2html/tags/Tag.java
+++ b/library/src/main/java/j2html/tags/Tag.java
@@ -23,38 +23,6 @@ public abstract class Tag<T extends Tag<T>> extends DomContent {
         return tagName != null && !tagName.isEmpty();
     }
 
-    String renderOpenTag() throws IOException {
-        StringBuilder stringBuilder = new StringBuilder();
-        renderOpenTag(stringBuilder, null);
-        return stringBuilder.toString();
-    }
-
-    String renderCloseTag() throws IOException {
-        StringBuilder stringBuilder = new StringBuilder();
-        renderCloseTag(stringBuilder);
-        return stringBuilder.toString();
-    }
-
-    protected void renderOpenTag(Appendable writer, Object model) throws IOException {
-        if (!hasTagName()) { // avoid <null> and <> tags
-            return;
-        }
-        writer.append("<").append(tagName);
-        for (Attribute attribute : attributes) {
-            attribute.renderModel(writer, model);
-        }
-        writer.append(">");
-    }
-
-    protected void renderCloseTag(Appendable writer) throws IOException {
-        if (!hasTagName()) { // avoid <null> and <> tags
-            return;
-        }
-        writer.append("</");
-        writer.append(tagName);
-        writer.append(">");
-    }
-
     protected ArrayList<Attribute> getAttributes() {
         return attributes;
     }

--- a/library/src/test/java/j2html/tags/TagTest.java
+++ b/library/src/test/java/j2html/tags/TagTest.java
@@ -1,11 +1,14 @@
 package j2html.tags;
 
 import j2html.Config;
+import j2html.attributes.Attribute;
 import j2html.model.DynamicHrefAttribute;
 import java.io.File;
 import java.io.FileWriter;
 
 import j2html.tags.specialized.manual.HtmlTag;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import static j2html.TagCreator.body;
 import static j2html.TagCreator.div;
@@ -13,18 +16,102 @@ import static j2html.TagCreator.footer;
 import static j2html.TagCreator.header;
 import static j2html.TagCreator.html;
 import static j2html.TagCreator.iff;
-import static j2html.TagCreator.img;
-import static j2html.TagCreator.input;
 import static j2html.TagCreator.main;
 import static j2html.TagCreator.p;
 import static j2html.TagCreator.tag;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
 
 public class TagTest {
 
+    @Before
+    public void setUp(){
+        Config.closeEmptyTags = false;
+    }
+
+    @After
+    public void tearDown(){
+        // Restore Config defaults.
+        Config.closeEmptyTags = false;
+    }
+
+    // TODO Introduce a different concept for a sequence of tags, and require valid names for all Tags.
+
     @Test
-    public void testRender() throws Exception {
+    public void unnamed_containers_do_not_render_tags_or_attributes(){
+        Tag tag = new ContainerTag(null).attr("xyz", "123");
+        assertThat(tag.render(), is(""));
+    }
+
+    @Test
+    public void unnamed_containers_render_children(){
+        ContainerTag tag = new ContainerTag(null)
+            .with(new EmptyTag("abc"))
+            .with(new ContainerTag("def"))
+            .withText("ghi");
+        assertThat(tag.render(), is("<abc><def></def>ghi"));
+    }
+
+    @Test
+    public void named_containers_without_children_only_render_tags_and_attributes(){
+        Tag tag = new ContainerTag("abc").attr("xyz", "123");
+        assertThat(tag.render(), is("<abc xyz=\"123\"></abc>"));
+    }
+
+    @Test
+    public void populated_named_containers_render_tags_attributes_and_children(){
+        Tag tag = new ContainerTag("abc")
+            .with(new EmptyTag("def"))
+            .with(new ContainerTag("ghi"))
+            .withText("jkl")
+            .attr("xyz", "123");
+        assertThat(tag.render(), is("<abc xyz=\"123\"><def><ghi></ghi>jkl</abc>"));
+    }
+
+    @Test
+    public void empty_tags_must_be_named(){
+        try{
+            new EmptyTag(null);
+            fail("Exception was not thrown.");
+        }catch (IllegalArgumentException e){
+            assertThat(e.getMessage(), is("Illegal tag name: null"));
+        }
+
+        try{
+            new EmptyTag("");
+            fail("Exception was not thrown.");
+        }catch (IllegalArgumentException e){
+            assertThat(e.getMessage(), is("Illegal tag name: \"\""));
+        }
+    }
+
+    @Test
+    public void empty_tags_can_be_configured_to_self_close(){
+        // By default they will not be self-closing.
+        assertThat(new EmptyTag("xyz").render(), is("<xyz>"));
+
+        Config.closeEmptyTags = true;
+        assertThat(new EmptyTag("xyz").render(), is("<xyz/>"));
+    }
+
+    @Test
+    public void attributes_are_rendered_in_the_order_that_they_are_defined(){
+        Tag container = new ContainerTag("abc")
+            .attr("a","A")
+            .attr(new Attribute("b","B"))
+            .attr("c");
+        assertThat(container.render(), is("<abc a=\"A\" b=\"B\" c></abc>"));
+
+        Tag tag = new EmptyTag("abc")
+            .attr("c")
+            .attr(new Attribute("b","B"))
+            .attr("a","A");
+        assertThat(tag.render(), is("<abc c b=\"B\" a=\"A\">"));
+    }
+
+    @Test
+    public void testRender() {
         ContainerTag testTag = new ContainerTag("a");
         testTag.setAttribute("href", "http://example.com");
         assertThat(testTag.render(), is("<a href=\"http://example.com\"></a>"));
@@ -41,33 +128,6 @@ public class TagTest {
     }
 
     @Test
-    public void testOpenTag() throws Exception {
-        ContainerTag testTag = new ContainerTag("a");
-        assertThat(testTag.renderOpenTag(), is("<a>"));
-
-        ContainerTag complexTestTag = new ContainerTag("input");
-        complexTestTag.attr("type","password").withId("password")
-            .attr("name","password")
-            .attr("placeholder","Password").attr("required");
-        String expectedResult = "<input type=\"password\" id=\"password\" name=\"password\" placeholder=\"Password\" required>";
-        assertThat(complexTestTag.renderOpenTag(), is(expectedResult));
-    }
-
-    @Test
-    public void testCloseTag() throws Exception {
-        ContainerTag testTag = new ContainerTag("a");
-        assertThat(testTag.renderCloseTag(), is("</a>"));
-    }
-
-    @Test
-    public void testSelfClosingTags() throws Exception {
-        Config.closeEmptyTags = true;
-        assertThat(img().withSrc("/test.png").render(), is("<img src=\"/test.png\"/>"));
-        assertThat(input().attr("type","text").render(), is("<input type=\"text\"/>"));
-        Config.closeEmptyTags = false;
-    }
-
-    @Test
     public void testFormattedTags() throws Exception { // better test in ComplexRenderTest.java
         assertThat(div(p("Hello")).renderFormatted(), is("<div>\n    <p>\n        Hello\n    </p>\n</div>\n"));
     }
@@ -80,13 +140,18 @@ public class TagTest {
     }
 
     @Test
-    public void testAcceptObjectValueAttribute() throws Exception {
-        Tag complexTestTag = new ContainerTag("input")
-            .attr("attr1", "value1")
-            .attr("attr2", 2)
-            .attr("attr3", null);
-        String expectedResult = "<input attr1=\"value1\" attr2=\"2\" attr3>";
-        assertThat(complexTestTag.renderOpenTag(), is(expectedResult));
+    public void attribute_values_are_converted_to_strings() throws Exception {
+        Tag container = new ContainerTag("abc")
+            .attr("string", "value1")
+            .attr("integer", 2)
+            .attr("none", null);
+        assertThat(container.render(), is("<abc string=\"value1\" integer=\"2\" none></abc>"));
+
+        Tag tag = new EmptyTag("abc")
+            .attr("string", "value1")
+            .attr("integer", 2)
+            .attr("none", null);
+        assertThat(tag.render(), is("<abc string=\"value1\" integer=\"2\" none>"));
     }
 
     @Test


### PR DESCRIPTION
…and tests to clarify current behavior.

I'm just dipping into the project so this commit will offer a view into my thoughts and coding style.  My goal was to understand the class relationships, and I started by defining some additional tests to clarify current behaviors. Along the way I noticed that some methods were exposed solely for testing and figured they'd make good candidates for removal.  From there it was possible to shift render*Tag methods from Tag into ContainerTag, as that was the only subclass to make use of them.  While testing I also thought it'd be beneficial to enforce non-null/non-empty tag names for EmptyTag, since it could generate invalid HTML without those checks.

You can see that my conventions for test naming are drastically different.  I don't mind following the current project conventions if you'd like, but I have found that this style (recommended by Kevlin Henney) of propositional naming makes it much easier to understand what is being tested.