### PR TITLE
Add renderFormatted() and renderFormatted(Appendable) to Renderable

### DIFF
--- a/library/src/main/java/j2html/tags/DomContent.java
+++ b/library/src/main/java/j2html/tags/DomContent.java
@@ -1,8 +1,22 @@
 package j2html.tags;
 
+import java.io.IOException;
+
+import j2html.Config;
+
 public abstract class DomContent implements Renderable {
     @Override
     public String toString() {
         return render();
+    }
+
+    protected void renderFormatted(Appendable writer, int level) throws IOException {
+        indent(writer, level);
+        render(writer);
+        writer.append("\n");
+    }
+
+    protected static void indent(Appendable appendable, int level) throws IOException {
+        appendable.append(Config.indenter.indent(level, ""));
     }
 }

--- a/library/src/main/java/j2html/tags/Renderable.java
+++ b/library/src/main/java/j2html/tags/Renderable.java
@@ -5,8 +5,7 @@ import java.io.IOException;
 public interface Renderable {
 
     /**
-     * Create a StringBuilder and use it to render the Renderable and it's
-     * children
+     * Render the Renderable and its children as a string.
      */
     default String render() {
         StringBuilder stringBuilder = new StringBuilder();
@@ -19,7 +18,7 @@ public interface Renderable {
     }
 
     /**
-     * Render the Renderable and it's children using the supplied writer
+     * Render the Renderable and its children using the supplied {@code writer}.
      *
      * @param writer the current writer
      */
@@ -28,10 +27,37 @@ public interface Renderable {
     }
 
     /**
-     * Render the Renderable and it's children using the supplied writer and a model.
+     * Render the Renderable and its children using the supplied {@code writer} and
+     * a {@code model}.
      *
      * @param writer the current writer
      * @param model  a model object to provide data for children to render
      */
     void renderModel(Appendable writer, Object model) throws IOException;
+
+    /**
+     * Render the Renderable and its children as a string, adding newlines before
+     * each child and using {@link j2html.Config#indenter} to indent a child based
+     * on how deep in the tree it is
+     */
+    default String renderFormatted() {
+        StringBuilder stringBuilder = new StringBuilder();
+        try {
+            renderFormatted(stringBuilder);
+        } catch (IOException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+        return stringBuilder.toString();
+    }
+
+    /**
+     * Render the Renderable and its children using the supplier {@code writer},
+     * adding newlines before each child and using {@link j2html.Config#indenter} to
+     * indent a child based on how deep in the tree it is
+     *
+     * @param writer the current writer
+     */
+    default void renderFormatted(Appendable writer) throws IOException {
+        render(writer); // to be overridden by subclasses
+    }
 }

--- a/library/src/test/java/j2html/tags/RenderFormattedTest.java
+++ b/library/src/test/java/j2html/tags/RenderFormattedTest.java
@@ -1,11 +1,16 @@
 package j2html.tags;
 
 import org.junit.Test;
+
+import static j2html.TagCreator.body;
+import static j2html.TagCreator.br;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.each;
+import static j2html.TagCreator.hr;
 import static j2html.TagCreator.li;
 import static j2html.TagCreator.p;
 import static j2html.TagCreator.pre;
+import static j2html.TagCreator.rawHtml;
 import static j2html.TagCreator.span;
 import static j2html.TagCreator.textarea;
 import static j2html.TagCreator.ul;
@@ -16,12 +21,12 @@ import static org.hamcrest.Matchers.is;
 public class RenderFormattedTest {
 
     @Test
-    public void testFormattedTags() throws Exception {
+    public void testFormattedTags() {
         assertThat(div(p("Hello")).renderFormatted(), is("<div>\n    <p>\n        Hello\n    </p>\n</div>\n"));
     }
 
     @Test
-    public void testFormattedTags_doesntFormatPre() throws Exception {
+    public void testFormattedTags_doesntFormatPre() {
         assertThat(div(pre("public void renderModel(Appendable writer, Object model) throws IOException {\n" +
             "        writer.append(text);\n" +
             "    }")).renderFormatted(), is("<div>\n" +
@@ -32,7 +37,7 @@ public class RenderFormattedTest {
     }
 
     @Test
-    public void testFormattedTags_doesntFormatPreChildren() throws Exception {
+    public void testFormattedTags_doesntFormatPreChildren() {
         assertThat(div(pre("public void renderModel(Appendable writer, Object model) throws IOException {\n" +
             "        writer.append(text);\n" +
             "    }").with(span("Test"))).renderFormatted(), is("<div>\n" +
@@ -43,7 +48,7 @@ public class RenderFormattedTest {
     }
 
     @Test
-    public void testFormattedTags_doesntFormatTextArea() throws Exception {
+    public void testFormattedTags_doesntFormatTextArea() {
         assertThat(div(textarea("fred\ntom")).renderFormatted(), is("<div>\n" +
             "    <textarea>fred\n" +
             "tom</textarea>\n" +
@@ -51,7 +56,7 @@ public class RenderFormattedTest {
     }
 
     @Test
-    public void testFormattedTags_each() throws Exception {
+    public void testFormattedTags_each() {
         assertThat(ul(each(asList(1, 2, 3), i -> li("Number " + i))).renderFormatted(), is(
             "<ul>\n" +
                 "    <li>\n" +
@@ -68,7 +73,7 @@ public class RenderFormattedTest {
     }
 
     @Test
-    public void testFormattedTags_nestedEach() throws Exception {
+    public void testFormattedTags_nestedEach() {
         assertThat(div(ul(each(asList(1, 2, 3), i -> li("Number " + i)))).renderFormatted(), is(
             "<div>\n" +
                 "    <ul>\n" +
@@ -86,4 +91,19 @@ public class RenderFormattedTest {
         ));
     }
 
+    @Test
+    public void shouldIndentEmptyTags() {
+        assertThat(body(div(span("line 1"), br(), rawHtml("line 2"), hr())).renderFormatted(), is(
+            "<body>\n" +
+                "    <div>\n" +
+                "        <span>\n" +
+                "            line 1\n" +
+                "        </span>\n" +
+                "        <br>\n" +
+                "        line 2\n" +
+                "        <hr>\n" +
+                "    </div>\n" +
+                "</body>\n"
+        ));
+    }
 }


### PR DESCRIPTION
for writing formatted markup directly into a file/writer/etc.

Simplifies the renderFormatted() implementation in ContainerTag by moving the code
for the non-ContainerTag children into the DomContent base class.