### PR TITLE
Extracted rendering functionality into implementations of HtmlBuilder.

### DIFF
--- a/library/src/main/java/j2html/Config.java
+++ b/library/src/main/java/j2html/Config.java
@@ -6,6 +6,7 @@ import j2html.utils.Indenter;
 import j2html.utils.JSMin;
 import j2html.utils.Minifier;
 import j2html.utils.TextEscaper;
+
 import java.util.Collections;
 
 public class Config {
@@ -38,7 +39,110 @@ public class Config {
     public static Indenter indenter = (level, text) -> String.join("", Collections.nCopies(level, FOUR_SPACES)) + text;
 
 
-    private Config() {
+    private TextEscaper _textEscaper;
+    private Minifier _cssMinifier;
+    private Minifier _jsMinifier;
+    private boolean _closeEmptyTags;
+    private Indenter _indenter;
+
+
+    private Config(
+        TextEscaper _textEscaper,
+        Minifier _cssMinifier,
+        Minifier _jsMinifier,
+        boolean _closeEmptyTags,
+        Indenter _indenter
+    ) {
+        this._textEscaper = _textEscaper;
+        this._cssMinifier = _cssMinifier;
+        this._jsMinifier = _jsMinifier;
+        this._closeEmptyTags = _closeEmptyTags;
+        this._indenter = _indenter;
+    }
+
+    /**
+     * A copy constructor.
+     *
+     * @param original The Config to copy fields from.
+     */
+    private Config(Config original) {
+        this._textEscaper = original._textEscaper;
+        this._cssMinifier = original._cssMinifier;
+        this._jsMinifier = original._jsMinifier;
+        this._closeEmptyTags = original._closeEmptyTags;
+        this._indenter = original._indenter;
+    }
+
+    public TextEscaper textEscaper() {
+        return _textEscaper;
+    }
+
+    public Minifier cssMinifier() {
+        return _cssMinifier;
+    }
+
+    public Minifier jsMinifier() {
+        return _jsMinifier;
+    }
+
+    public boolean closeEmptyTags() {
+        return _closeEmptyTags;
+    }
+
+    public Indenter indenter() {
+        return _indenter;
+    }
+
+    public Config withTextEscaper(TextEscaper textEscaper){
+        Config copy = new Config(this);
+        copy._textEscaper = textEscaper;
+        return copy;
+    }
+
+    public Config withCssMinifier(Minifier cssMinifier){
+        Config copy = new Config(this);
+        copy._cssMinifier = cssMinifier;
+        return copy;
+    }
+
+    public Config withJsMinifier(Minifier jsMinifier){
+        Config copy = new Config(this);
+        copy._jsMinifier = jsMinifier;
+        return copy;
+    }
+
+    public Config withEmptyTagsClosed(boolean closeEmptyTags){
+        Config copy = new Config(this);
+        copy._closeEmptyTags = closeEmptyTags;
+        return copy;
+    }
+
+    public Config withIndenter(Indenter indenter){
+        Config copy = new Config(this);
+        copy._indenter = indenter;
+        return copy;
+    }
+
+    private static final Config DEFAULTS = new Config(
+        EscapeUtil::escape,
+        CSSMin::compressCss,
+        JSMin::compressJs,
+        false,
+        (level, text) -> String.join("", Collections.nCopies(level, FOUR_SPACES)) + text
+    );
+
+    public static final Config defaults() {
+        return DEFAULTS;
+    }
+
+    public static final Config global() {
+        return new Config(
+            textEscaper,
+            cssMinifier,
+            jsMinifier,
+            closeEmptyTags,
+            indenter
+        );
     }
 
 }

--- a/library/src/main/java/j2html/attributes/Attribute.java
+++ b/library/src/main/java/j2html/attributes/Attribute.java
@@ -1,7 +1,9 @@
 package j2html.attributes;
 
 import j2html.Config;
+import j2html.rendering.TagBuilder;
 import j2html.tags.Renderable;
+
 import java.io.IOException;
 
 public class Attribute implements Renderable {
@@ -19,17 +21,33 @@ public class Attribute implements Renderable {
     }
 
     @Override
+    @Deprecated
     public void renderModel(Appendable writer, Object model) throws IOException {
-        if (name == null) {
-            return;
+        if (writer instanceof TagBuilder) {
+            if (name != null) {
+                if (value != null) {
+                    ((TagBuilder) writer).appendAttribute(name, value);
+                } else {
+                    ((TagBuilder) writer).appendBooleanAttribute(name);
+                }
+            }
+        } else {
+            if (name == null) {
+                return;
+            }
+            writer.append(' ');
+            writer.append(name);
+            if (value != null) {
+                writer.append("=\"");
+                writer.append(Config.textEscaper.escape(value));
+                writer.append('"');
+            }
         }
-        writer.append(' ');
-        writer.append(name);
-        if (value != null) {
-            writer.append("=\"");
-            writer.append(Config.textEscaper.escape(value));
-            writer.append('"');
-        }
+    }
+
+    public void render(TagBuilder builder, Object model) throws IOException {
+        // Maintain compatibility with classes that extend Attribute, for now...
+        renderModel(builder, model);
     }
 
     public String getName() {
@@ -40,8 +58,7 @@ public class Attribute implements Renderable {
         this.value = value;
     }
 
-    public String getValue()
-    {
+    public String getValue() {
         return value;
     }
 }

--- a/library/src/main/java/j2html/rendering/FlatHtml.java
+++ b/library/src/main/java/j2html/rendering/FlatHtml.java
@@ -101,7 +101,7 @@ public class FlatHtml<T extends Appendable> implements HtmlBuilder<T> {
     }
 
     @Override
-    public HtmlBuilder appendEndTag(String name) throws IOException {
+    public HtmlBuilder<T> appendEndTag(String name) throws IOException {
         out.append("</").append(name).append(">");
         return this;
     }

--- a/library/src/main/java/j2html/rendering/FlatHtml.java
+++ b/library/src/main/java/j2html/rendering/FlatHtml.java
@@ -113,7 +113,7 @@ public class FlatHtml<T extends Appendable> implements HtmlBuilder<T> {
     }
 
     @Override
-    public HtmlBuilder appendEscapedText(String txt) throws IOException {
+    public HtmlBuilder<T> appendEscapedText(String txt) throws IOException {
         out.append(textEscaper.escape(txt));
         return this;
     }

--- a/library/src/main/java/j2html/rendering/FlatHtml.java
+++ b/library/src/main/java/j2html/rendering/FlatHtml.java
@@ -119,7 +119,7 @@ public class FlatHtml<T extends Appendable> implements HtmlBuilder<T> {
     }
 
     @Override
-    public HtmlBuilder appendUnescapedText(String txt) throws IOException {
+    public HtmlBuilder<T> appendUnescapedText(String txt) throws IOException {
         out.append(txt);
         return this;
     }

--- a/library/src/main/java/j2html/rendering/FlatHtml.java
+++ b/library/src/main/java/j2html/rendering/FlatHtml.java
@@ -75,7 +75,7 @@ public class FlatHtml<T extends Appendable> implements HtmlBuilder<T> {
 
     @Override
     @Deprecated
-    public HtmlBuilder append(CharSequence csq) throws IOException {
+    public HtmlBuilder<T> append(CharSequence csq) throws IOException {
         out.append(csq);
         return this;
     }

--- a/library/src/main/java/j2html/rendering/FlatHtml.java
+++ b/library/src/main/java/j2html/rendering/FlatHtml.java
@@ -33,8 +33,8 @@ public class FlatHtml<T extends Appendable> implements HtmlBuilder<T> {
      * @param <T>    The type of the Appendable to which HTML will be appended.
      * @return An HtmlBuilder for flat HTML.
      */
-    public static final <T extends Appendable> FlatHtml into(T out, Config config) {
-        return new FlatHtml(out, config);
+    public static final <T extends Appendable> FlatHtml<T> into(T out, Config config) {
+        return new FlatHtml<>(out, config);
     }
 
     /**

--- a/library/src/main/java/j2html/rendering/FlatHtml.java
+++ b/library/src/main/java/j2html/rendering/FlatHtml.java
@@ -20,8 +20,8 @@ public class FlatHtml<T extends Appendable> implements HtmlBuilder<T> {
      * @param <T> The type of the Appendable to which HTML will be appended.
      * @return An HtmlBuilder for flat HTML.
      */
-    public static final <T extends Appendable> FlatHtml into(T out) {
-        return new FlatHtml(out, Config.defaults());
+    public static final <T extends Appendable> FlatHtml<T> into(T out) {
+        return new FlatHtml<>(out, Config.defaults());
     }
 
     /**

--- a/library/src/main/java/j2html/rendering/FlatHtml.java
+++ b/library/src/main/java/j2html/rendering/FlatHtml.java
@@ -89,7 +89,7 @@ public class FlatHtml<T extends Appendable> implements HtmlBuilder<T> {
 
     @Override
     @Deprecated
-    public HtmlBuilder append(char c) throws IOException {
+    public HtmlBuilder<T> append(char c) throws IOException {
         out.append(c);
         return this;
     }

--- a/library/src/main/java/j2html/rendering/FlatHtml.java
+++ b/library/src/main/java/j2html/rendering/FlatHtml.java
@@ -149,7 +149,7 @@ public class FlatHtml<T extends Appendable> implements HtmlBuilder<T> {
         }
 
         @Override
-        public HtmlBuilder completeTag() throws IOException {
+        public HtmlBuilder<T> completeTag() throws IOException {
             if (closeTag) {
                 out.append("/");
             }

--- a/library/src/main/java/j2html/rendering/FlatHtml.java
+++ b/library/src/main/java/j2html/rendering/FlatHtml.java
@@ -82,7 +82,7 @@ public class FlatHtml<T extends Appendable> implements HtmlBuilder<T> {
 
     @Override
     @Deprecated
-    public HtmlBuilder append(CharSequence csq, int start, int end) throws IOException {
+    public HtmlBuilder<T> append(CharSequence csq, int start, int end) throws IOException {
         out.append(csq, start, end);
         return this;
     }

--- a/library/src/main/java/j2html/rendering/FlatHtml.java
+++ b/library/src/main/java/j2html/rendering/FlatHtml.java
@@ -1,0 +1,182 @@
+package j2html.rendering;
+
+import j2html.Config;
+import j2html.utils.TextEscaper;
+
+import java.io.IOException;
+
+/**
+ * Composes HTML without any extra line breaks or indentation.
+ *
+ * @param <T> The type of the Appendable to which HTML will be appended.
+ */
+public class FlatHtml<T extends Appendable> implements HtmlBuilder<T> {
+
+    /**
+     * Returns an HtmlBuilder that will generate flat HTML using
+     * Config defaults.
+     *
+     * @param out The Appendable to which HTML will be appended.
+     * @param <T> The type of the Appendable to which HTML will be appended.
+     * @return An HtmlBuilder for flat HTML.
+     */
+    public static final <T extends Appendable> FlatHtml into(T out) {
+        return new FlatHtml(out, Config.defaults());
+    }
+
+    /**
+     * Returns an HtmlBuilder that will generate flat HTML using
+     * the given Config.
+     *
+     * @param out    The Appendable to which HTML will be appended.
+     * @param config The Config which will specify text escapement, tag closing, etc.
+     * @param <T>    The type of the Appendable to which HTML will be appended.
+     * @return An HtmlBuilder for flat HTML.
+     */
+    public static final <T extends Appendable> FlatHtml into(T out, Config config) {
+        return new FlatHtml(out, config);
+    }
+
+    /**
+     * Returns an HtmlBuilder that will generate flat HTML in memory
+     * using Config defaults.
+     *
+     * @return An HtmlBuilder for flat HTML.
+     */
+    public static final FlatHtml<StringBuilder> inMemory() {
+        return into(new StringBuilder());
+    }
+
+    /**
+     * Returns an HtmlBuilder that will generate flat HTML in memory
+     * using the given Config.
+     * @param config The Config which will specify text escapement, tag closing, etc.
+     * @return An HtmlBuilder for flat HTML.
+     */
+    public static final FlatHtml<StringBuilder> inMemory(Config config) {
+        return into(new StringBuilder(), config);
+    }
+
+    private final T out;
+    private final TextEscaper textEscaper;
+    private final TagBuilder enclosingElementAttributes;
+    private final TagBuilder emptyElementAttributes;
+
+    private FlatHtml(T out, Config config) {
+        this.out = out;
+        this.textEscaper = config.textEscaper();
+        this.enclosingElementAttributes = new FlatTagBuilder(false);
+        this.emptyElementAttributes = new FlatTagBuilder(config.closeEmptyTags());
+    }
+
+    public T output() {
+        return out;
+    }
+
+    @Override
+    @Deprecated
+    public HtmlBuilder append(CharSequence csq) throws IOException {
+        out.append(csq);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public HtmlBuilder append(CharSequence csq, int start, int end) throws IOException {
+        out.append(csq, start, end);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public HtmlBuilder append(char c) throws IOException {
+        out.append(c);
+        return this;
+    }
+
+    @Override
+    public TagBuilder appendStartTag(String name) throws IOException {
+        out.append("<").append(name);
+        return enclosingElementAttributes;
+    }
+
+    @Override
+    public HtmlBuilder appendEndTag(String name) throws IOException {
+        out.append("</").append(name).append(">");
+        return this;
+    }
+
+    @Override
+    public TagBuilder appendEmptyTag(String name) throws IOException {
+        out.append("<").append(name);
+        return emptyElementAttributes;
+    }
+
+    @Override
+    public HtmlBuilder appendEscapedText(String txt) throws IOException {
+        out.append(textEscaper.escape(txt));
+        return this;
+    }
+
+    @Override
+    public HtmlBuilder appendUnescapedText(String txt) throws IOException {
+        out.append(txt);
+        return this;
+    }
+
+    private class FlatTagBuilder implements TagBuilder {
+
+        private final boolean closeTag;
+
+        private FlatTagBuilder(boolean closeTag) {
+            this.closeTag = closeTag;
+        }
+
+        @Override
+        public TagBuilder appendAttribute(String name, String value) throws IOException {
+            out.append(" ")
+                .append(name)
+                .append("=\"")
+                .append(textEscaper.escape(value))
+                .append("\"");
+            return this;
+        }
+
+        @Override
+        public TagBuilder appendBooleanAttribute(String name) throws IOException {
+            out.append(" ").append(name);
+            return this;
+        }
+
+        @Override
+        public HtmlBuilder completeTag() throws IOException {
+            if (closeTag) {
+                out.append("/");
+            }
+            out.append(">");
+
+            return FlatHtml.this;
+        }
+
+        @Override
+        @Deprecated
+        public TagBuilder append(CharSequence csq) throws IOException {
+            out.append(csq);
+            return this;
+        }
+
+        @Override
+        @Deprecated
+        public TagBuilder append(CharSequence csq, int start, int end) throws IOException {
+            out.append(csq, start, end);
+            return this;
+        }
+
+        @Override
+        @Deprecated
+        public TagBuilder append(char c) throws IOException {
+            out.append(c);
+            return this;
+        }
+    }
+}

--- a/library/src/main/java/j2html/rendering/HtmlBuilder.java
+++ b/library/src/main/java/j2html/rendering/HtmlBuilder.java
@@ -77,7 +77,7 @@ public interface HtmlBuilder<T extends Appendable> extends Appendable {
 
     @Override
     @Deprecated
-    HtmlBuilder append(CharSequence csq) throws IOException;
+    HtmlBuilder<T> append(CharSequence csq) throws IOException;
 
     @Override
     @Deprecated

--- a/library/src/main/java/j2html/rendering/HtmlBuilder.java
+++ b/library/src/main/java/j2html/rendering/HtmlBuilder.java
@@ -81,7 +81,7 @@ public interface HtmlBuilder<T extends Appendable> extends Appendable {
 
     @Override
     @Deprecated
-    HtmlBuilder append(CharSequence csq, int start, int end) throws IOException;
+    HtmlBuilder<T> append(CharSequence csq, int start, int end) throws IOException;
 
     @Override
     @Deprecated

--- a/library/src/main/java/j2html/rendering/HtmlBuilder.java
+++ b/library/src/main/java/j2html/rendering/HtmlBuilder.java
@@ -85,5 +85,5 @@ public interface HtmlBuilder<T extends Appendable> extends Appendable {
 
     @Override
     @Deprecated
-    HtmlBuilder append(char c) throws IOException;
+    HtmlBuilder<T> append(char c) throws IOException;
 }

--- a/library/src/main/java/j2html/rendering/HtmlBuilder.java
+++ b/library/src/main/java/j2html/rendering/HtmlBuilder.java
@@ -1,0 +1,89 @@
+package j2html.rendering;
+
+import java.io.IOException;
+
+/**
+ * Implementations of HtmlBuilder are wrappers around an
+ * Appendable, and support appending HTML-specific character
+ * sequences to that Appendable.
+ * <p>
+ * Note:  HtmlBuilder extends Appendable for compatibility with
+ * previous version of this library.  This extension will probably be
+ * removed in the future, so avoid relying on the deprecated methods
+ * of this interface.
+ *
+ * @param <T> The type of the Appendable.  Used so that the
+ *            same type can be returned to the caller, allowing
+ *            for additional work to be done on the Appendable
+ *            without the need for manual casting.
+ */
+public interface HtmlBuilder<T extends Appendable> extends Appendable {
+
+    /**
+     * Appends a start tag with the given name to the output. The
+     * returned TagBuilder is then used to append attributes
+     * and eventually complete the start tag.
+     *
+     * @param name The name of the start tag.
+     * @return An TagBuilder which can append attributes to the start tag.
+     * @throws IOException When the Appendable throws an IOException.
+     */
+    TagBuilder appendStartTag(String name) throws IOException;
+
+    /**
+     * Appends an end tag with the given name to the output.
+     *
+     * @param name The name of the end tag.
+     * @return An HtmlBuilder that can continue appending HTML to the output.
+     * @throws IOException When the Appendable throws an IOException.
+     */
+    HtmlBuilder<T> appendEndTag(String name) throws IOException;
+
+    /**
+     * Appends an empty tag with the given name to the output. The
+     * returned TagBuilder is then used to append attributes
+     * and eventually complete the empty tag.
+     *
+     * @param name The name of the empty tag.
+     * @return An TagBuilder which can append attributes to the empty tag.
+     * @throws IOException When the Appendable throws an IOException.
+     */
+    TagBuilder appendEmptyTag(String name) throws IOException;
+
+    /**
+     * Appends escaped text to the output.
+     *
+     * @param txt The text to append.
+     * @return An HtmlBuilder that can continue appending HTML to the output.
+     * @throws IOException When the Appendable throws an IOException.
+     */
+    HtmlBuilder<T> appendEscapedText(String txt) throws IOException;
+
+    /**
+     * Appends unescaped text to the output.
+     *
+     * @param txt The text to append.
+     * @return An HtmlBuilder that can continue appending HTML to the output.
+     * @throws IOException When the Appendable throws an IOException.
+     */
+    HtmlBuilder<T> appendUnescapedText(String txt) throws IOException;
+
+    /**
+     * Returns the Appendable that was being wrapped.
+     *
+     * @return The original Appendable.
+     */
+    T output();
+
+    @Override
+    @Deprecated
+    HtmlBuilder append(CharSequence csq) throws IOException;
+
+    @Override
+    @Deprecated
+    HtmlBuilder append(CharSequence csq, int start, int end) throws IOException;
+
+    @Override
+    @Deprecated
+    HtmlBuilder append(char c) throws IOException;
+}

--- a/library/src/main/java/j2html/rendering/IndentedHtml.java
+++ b/library/src/main/java/j2html/rendering/IndentedHtml.java
@@ -58,7 +58,7 @@ public class IndentedHtml<T extends Appendable> implements HtmlBuilder<T> {
      * @param <T>    The type of the Appendable to which HTML will be appended.
      * @return An HtmlBuilder for indented HTML.
      */
-    public static final <T extends Appendable> IndentedHtml inMemory(Config config) {
+    public static final IndentedHtml<StringBuilder> inMemory(Config config) {
         return into(new StringBuilder(), config);
     }
 

--- a/library/src/main/java/j2html/rendering/IndentedHtml.java
+++ b/library/src/main/java/j2html/rendering/IndentedHtml.java
@@ -46,7 +46,7 @@ public class IndentedHtml<T extends Appendable> implements HtmlBuilder<T> {
      * @param <T> The type of the Appendable to which HTML will be appended.
      * @return An HtmlBuilder for indented HTML.
      */
-    public static final <T extends Appendable> IndentedHtml inMemory() {
+    public static final IndentedHtml<StringBuilder> inMemory() {
         return into(new StringBuilder());
     }
 

--- a/library/src/main/java/j2html/rendering/IndentedHtml.java
+++ b/library/src/main/java/j2html/rendering/IndentedHtml.java
@@ -22,8 +22,8 @@ public class IndentedHtml<T extends Appendable> implements HtmlBuilder<T> {
      * @param <T> The type of the Appendable to which HTML will be appended.
      * @return An HtmlBuilder for indented HTML.
      */
-    public static final <T extends Appendable> IndentedHtml into(T out) {
-        return new IndentedHtml(out, Config.defaults());
+    public static final <T extends Appendable> IndentedHtml<T> into(T out) {
+        return new IndentedHtml<>(out, Config.defaults());
     }
 
     /**

--- a/library/src/main/java/j2html/rendering/IndentedHtml.java
+++ b/library/src/main/java/j2html/rendering/IndentedHtml.java
@@ -5,7 +5,8 @@ import j2html.utils.Indenter;
 import j2html.utils.TextEscaper;
 
 import java.io.IOException;
-import java.util.Stack;
+import java.util.ArrayDeque;
+import java.util.Deque;
 
 /**
  * Composes HTML with lines breaks and indentation between tags and text.
@@ -43,7 +44,6 @@ public class IndentedHtml<T extends Appendable> implements HtmlBuilder<T> {
      * Returns an HtmlBuilder that will generate indented HTML in memory using
      * Config defaults.
      *
-     * @param <T> The type of the Appendable to which HTML will be appended.
      * @return An HtmlBuilder for indented HTML.
      */
     public static final IndentedHtml<StringBuilder> inMemory() {
@@ -55,7 +55,6 @@ public class IndentedHtml<T extends Appendable> implements HtmlBuilder<T> {
      * the given Config.
      *
      * @param config The Config which will specify indentation, text escapement, tag closing, etc.
-     * @param <T>    The type of the Appendable to which HTML will be appended.
      * @return An HtmlBuilder for indented HTML.
      */
     public static final IndentedHtml<StringBuilder> inMemory(Config config) {
@@ -74,7 +73,7 @@ public class IndentedHtml<T extends Appendable> implements HtmlBuilder<T> {
     // as those tags are closed.  Determining whether or not we are
     // currently rendering into a preformatted element is as simple as
     // asking if any tags on the stack match a preformatted element name.
-    private Stack<String> trace = new Stack<>();
+    private final Deque<String> trace = new ArrayDeque<>();
 
     private IndentedHtml(T out, Config config) {
         this.out = out;

--- a/library/src/main/java/j2html/rendering/IndentedHtml.java
+++ b/library/src/main/java/j2html/rendering/IndentedHtml.java
@@ -210,7 +210,7 @@ public class IndentedHtml<T extends Appendable> implements HtmlBuilder<T> {
         }
 
         @Override
-        public HtmlBuilder completeTag() throws IOException {
+        public HtmlBuilder<T> completeTag() throws IOException {
             if (closeTag) {
                 out.append("/");
             }

--- a/library/src/main/java/j2html/rendering/IndentedHtml.java
+++ b/library/src/main/java/j2html/rendering/IndentedHtml.java
@@ -1,0 +1,247 @@
+package j2html.rendering;
+
+import j2html.Config;
+import j2html.utils.Indenter;
+import j2html.utils.TextEscaper;
+
+import java.io.IOException;
+import java.util.Stack;
+
+/**
+ * Composes HTML with lines breaks and indentation between tags and text.
+ *
+ * @param <T> The type of the Appendable to which HTML will be appended.
+ */
+public class IndentedHtml<T extends Appendable> implements HtmlBuilder<T> {
+
+    /**
+     * Returns an HtmlBuilder that will generate indented HTML using
+     * Config defaults.
+     *
+     * @param out The Appendable to which HTML will be appended.
+     * @param <T> The type of the Appendable to which HTML will be appended.
+     * @return An HtmlBuilder for indented HTML.
+     */
+    public static final <T extends Appendable> IndentedHtml into(T out) {
+        return new IndentedHtml(out, Config.defaults());
+    }
+
+    /**
+     * Returns an HtmlBuilder that will generate indented HTML using
+     * the given Config.
+     *
+     * @param out    The Appendable to which HTML will be appended.
+     * @param config The Config which will specify indentation, text escapement, tag closing, etc.
+     * @param <T>    The type of the Appendable to which HTML will be appended.
+     * @return An HtmlBuilder for indented HTML.
+     */
+    public static final <T extends Appendable> IndentedHtml into(T out, Config config) {
+        return new IndentedHtml(out, config);
+    }
+
+    /**
+     * Returns an HtmlBuilder that will generate indented HTML in memory using
+     * Config defaults.
+     *
+     * @param <T> The type of the Appendable to which HTML will be appended.
+     * @return An HtmlBuilder for indented HTML.
+     */
+    public static final <T extends Appendable> IndentedHtml inMemory() {
+        return into(new StringBuilder());
+    }
+
+    /**
+     * Returns an HtmlBuilder that will generate indented HTML in memory using
+     * the given Config.
+     *
+     * @param config The Config which will specify indentation, text escapement, tag closing, etc.
+     * @param <T>    The type of the Appendable to which HTML will be appended.
+     * @return An HtmlBuilder for indented HTML.
+     */
+    public static final <T extends Appendable> IndentedHtml inMemory(Config config) {
+        return into(new StringBuilder(), config);
+    }
+
+    private final T out;
+    private final Indenter indenter;
+    private final TextEscaper textEscaper;
+    private final TagBuilder enclosingElementAttributes;
+    private final TagBuilder emptyElementAttributes;
+
+    // Dealing with preformatted elements (pre and textarea) requires
+    // that we know what our parent elements are.  To do that we use
+    // a stack; adding items as start tags are created, and removing them
+    // as those tags are closed.  Determining whether or not we are
+    // currently rendering into a preformatted element is as simple as
+    // asking if any tags on the stack match a preformatted element name.
+    private Stack<String> trace = new Stack<>();
+
+    private IndentedHtml(T out, Config config) {
+        this.out = out;
+        this.indenter = config.indenter();
+        this.textEscaper = config.textEscaper();
+        this.enclosingElementAttributes = new IndentedTagBuilder(false);
+        this.emptyElementAttributes = new IndentedTagBuilder(config.closeEmptyTags());
+    }
+
+    private boolean isContentSelfFormatting() {
+        return trace.contains("pre") || trace.contains("textarea");
+    }
+
+    private int lvl() {
+        return trace.size();
+    }
+
+    @Override
+    public TagBuilder appendStartTag(String name) throws IOException {
+        if (!isContentSelfFormatting()) {
+            out.append(indenter.indent(lvl(), ""));
+        }
+
+        trace.push(name);
+
+        out.append("<").append(name);
+        return enclosingElementAttributes;
+    }
+
+    @Override
+    public HtmlBuilder appendEndTag(String name) throws IOException {
+        if (!name.equals(trace.peek())) {
+            throw new RuntimeException("Incorrect element closed: " + name + ".  Expected: " + trace.peek());
+        }
+
+        if (!isContentSelfFormatting()) {
+            trace.pop();
+            out.append(indenter.indent(lvl(), ""));
+        } else {
+            trace.pop();
+        }
+
+        out.append("</").append(name).append(">");
+
+        if (!isContentSelfFormatting()) {
+            out.append("\n");
+        }
+
+        return this;
+    }
+
+    @Override
+    public TagBuilder appendEmptyTag(String name) throws IOException {
+        if (!isContentSelfFormatting()) {
+            out.append(indenter.indent(lvl(), ""));
+        }
+        out.append("<").append(name);
+        return emptyElementAttributes;
+    }
+
+    private void appendLines(String txt) throws IOException {
+        if (!isContentSelfFormatting()) {
+            String[] lines = txt.split("\n");
+            for (String line : lines) {
+                out.append(indenter.indent(lvl(), line)).append("\n");
+            }
+        } else {
+            out.append(txt);
+        }
+    }
+
+    @Override
+    public HtmlBuilder appendEscapedText(String txt) throws IOException {
+        appendLines(textEscaper.escape(txt));
+        return this;
+    }
+
+    @Override
+    public HtmlBuilder appendUnescapedText(String txt) throws IOException {
+        appendLines(txt);
+        return this;
+    }
+
+    @Override
+    public T output() {
+        return out;
+    }
+
+    @Override
+    @Deprecated
+    public HtmlBuilder append(CharSequence csq) throws IOException {
+        out.append(csq);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public HtmlBuilder append(CharSequence csq, int start, int end) throws IOException {
+        out.append(csq, start, end);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public HtmlBuilder append(char c) throws IOException {
+        out.append(c);
+        return this;
+    }
+
+
+    private class IndentedTagBuilder implements TagBuilder {
+
+        private final boolean closeTag;
+
+        private IndentedTagBuilder(boolean closeTag) {
+            this.closeTag = closeTag;
+        }
+
+        @Override
+        public TagBuilder appendAttribute(String name, String value) throws IOException {
+            out.append(" ")
+                .append(name)
+                .append("=\"")
+                .append(textEscaper.escape(value))
+                .append("\"");
+            return this;
+        }
+
+        @Override
+        public TagBuilder appendBooleanAttribute(String name) throws IOException {
+            out.append(" ").append(name);
+            return this;
+        }
+
+        @Override
+        public HtmlBuilder completeTag() throws IOException {
+            if (closeTag) {
+                out.append("/");
+            }
+            out.append(">");
+
+            if (!isContentSelfFormatting()) {
+                out.append("\n");
+            }
+
+            return IndentedHtml.this;
+        }
+
+        @Override
+        @Deprecated
+        public TagBuilder append(CharSequence csq) throws IOException {
+            out.append(csq);
+            return this;
+        }
+
+        @Override
+        @Deprecated
+        public TagBuilder append(CharSequence csq, int start, int end) throws IOException {
+            out.append(csq, start, end);
+            return this;
+        }
+
+        @Override
+        @Deprecated
+        public TagBuilder append(char c) throws IOException {
+            out.append(c);
+            return this;
+        }
+    }
+}

--- a/library/src/main/java/j2html/rendering/IndentedHtml.java
+++ b/library/src/main/java/j2html/rendering/IndentedHtml.java
@@ -179,7 +179,7 @@ public class IndentedHtml<T extends Appendable> implements HtmlBuilder<T> {
 
     @Override
     @Deprecated
-    public HtmlBuilder append(char c) throws IOException {
+    public HtmlBuilder<T> append(char c) throws IOException {
         out.append(c);
         return this;
     }

--- a/library/src/main/java/j2html/rendering/IndentedHtml.java
+++ b/library/src/main/java/j2html/rendering/IndentedHtml.java
@@ -105,7 +105,7 @@ public class IndentedHtml<T extends Appendable> implements HtmlBuilder<T> {
     }
 
     @Override
-    public HtmlBuilder appendEndTag(String name) throws IOException {
+    public HtmlBuilder<T> appendEndTag(String name) throws IOException {
         if (!name.equals(trace.peek())) {
             throw new RuntimeException("Incorrect element closed: " + name + ".  Expected: " + trace.peek());
         }

--- a/library/src/main/java/j2html/rendering/IndentedHtml.java
+++ b/library/src/main/java/j2html/rendering/IndentedHtml.java
@@ -165,7 +165,7 @@ public class IndentedHtml<T extends Appendable> implements HtmlBuilder<T> {
 
     @Override
     @Deprecated
-    public HtmlBuilder append(CharSequence csq) throws IOException {
+    public HtmlBuilder<T> append(CharSequence csq) throws IOException {
         out.append(csq);
         return this;
     }

--- a/library/src/main/java/j2html/rendering/IndentedHtml.java
+++ b/library/src/main/java/j2html/rendering/IndentedHtml.java
@@ -35,8 +35,8 @@ public class IndentedHtml<T extends Appendable> implements HtmlBuilder<T> {
      * @param <T>    The type of the Appendable to which HTML will be appended.
      * @return An HtmlBuilder for indented HTML.
      */
-    public static final <T extends Appendable> IndentedHtml into(T out, Config config) {
-        return new IndentedHtml(out, config);
+    public static final <T extends Appendable> IndentedHtml<T> into(T out, Config config) {
+        return new IndentedHtml<>(out, config);
     }
 
     /**

--- a/library/src/main/java/j2html/rendering/IndentedHtml.java
+++ b/library/src/main/java/j2html/rendering/IndentedHtml.java
@@ -172,7 +172,7 @@ public class IndentedHtml<T extends Appendable> implements HtmlBuilder<T> {
 
     @Override
     @Deprecated
-    public HtmlBuilder append(CharSequence csq, int start, int end) throws IOException {
+    public HtmlBuilder<T> append(CharSequence csq, int start, int end) throws IOException {
         out.append(csq, start, end);
         return this;
     }

--- a/library/src/main/java/j2html/rendering/IndentedHtml.java
+++ b/library/src/main/java/j2html/rendering/IndentedHtml.java
@@ -153,7 +153,7 @@ public class IndentedHtml<T extends Appendable> implements HtmlBuilder<T> {
     }
 
     @Override
-    public HtmlBuilder appendUnescapedText(String txt) throws IOException {
+    public HtmlBuilder<T> appendUnescapedText(String txt) throws IOException {
         appendLines(txt);
         return this;
     }

--- a/library/src/main/java/j2html/rendering/IndentedHtml.java
+++ b/library/src/main/java/j2html/rendering/IndentedHtml.java
@@ -147,7 +147,7 @@ public class IndentedHtml<T extends Appendable> implements HtmlBuilder<T> {
     }
 
     @Override
-    public HtmlBuilder appendEscapedText(String txt) throws IOException {
+    public HtmlBuilder<T> appendEscapedText(String txt) throws IOException {
         appendLines(textEscaper.escape(txt));
         return this;
     }

--- a/library/src/main/java/j2html/rendering/TagBuilder.java
+++ b/library/src/main/java/j2html/rendering/TagBuilder.java
@@ -41,7 +41,7 @@ public interface TagBuilder extends Appendable {
      * @return An HtmlBuilder that can continue appending HTML to the output.
      * @throws IOException When the Appendable throws an IOException.
      */
-    HtmlBuilder completeTag() throws IOException;
+    HtmlBuilder<? extends Appendable> completeTag() throws IOException;
 
     @Override
     @Deprecated

--- a/library/src/main/java/j2html/rendering/TagBuilder.java
+++ b/library/src/main/java/j2html/rendering/TagBuilder.java
@@ -1,0 +1,57 @@
+package j2html.rendering;
+
+import java.io.IOException;
+
+/**
+ * Implementations of TagBuilder are used to append HTML tag
+ * attributes to an Appendable.  TagBuilders are scoped to the
+ * creation and completion of a specific tag, and should not be used
+ * outside of that tag.
+ * <p>
+ * Note:  TagBuilder extends Appendable for compatibility with
+ * previous version of this library.  This extension will probably be
+ * removed in the future, so avoid relying on the deprecated methods
+ * of this interface.
+ */
+public interface TagBuilder extends Appendable {
+
+    /**
+     * Appends an key/value pair as an HTML attribute to the current tag.
+     *
+     * @param name  The name of an attribute.
+     * @param value The value of an attribute.
+     * @return An TagBuilder which can continue appending attributes.
+     * @throws IOException When the Appendable throws an IOException.
+     */
+    TagBuilder appendAttribute(String name, String value) throws IOException;
+
+    /**
+     * Appends a name, as a boolean HTML attribute to the current tag.
+     *
+     * @param name The name of the boolean attribute.
+     * @return An TagBuilder which can continue appending attributes.
+     * @throws IOException When the Appendable throws an IOException.
+     */
+    TagBuilder appendBooleanAttribute(String name) throws IOException;
+
+    /**
+     * Appends any characters which are necessary to close the current tag,
+     * and returns an HtmlBuilder that can continue appending to the output.
+     *
+     * @return An HtmlBuilder that can continue appending HTML to the output.
+     * @throws IOException When the Appendable throws an IOException.
+     */
+    HtmlBuilder completeTag() throws IOException;
+
+    @Override
+    @Deprecated
+    TagBuilder append(CharSequence csq) throws IOException;
+
+    @Override
+    @Deprecated
+    TagBuilder append(CharSequence csq, int start, int end) throws IOException;
+
+    @Override
+    @Deprecated
+    TagBuilder append(char c) throws IOException;
+}

--- a/library/src/main/java/j2html/tags/ContainerTag.java
+++ b/library/src/main/java/j2html/tags/ContainerTag.java
@@ -177,8 +177,8 @@ public class ContainerTag<T extends ContainerTag<T>> extends Tag<T> {
     @Override
     @Deprecated
     public void renderModel(Appendable writer, Object model) throws IOException {
-        HtmlBuilder builder = (writer instanceof HtmlBuilder)
-            ? (HtmlBuilder) writer
+        HtmlBuilder<?> builder = (writer instanceof HtmlBuilder)
+            ? (HtmlBuilder<?>) writer
             : FlatHtml.into(writer, Config.global());
 
         render(builder, model);

--- a/library/src/main/java/j2html/tags/ContainerTag.java
+++ b/library/src/main/java/j2html/tags/ContainerTag.java
@@ -2,6 +2,10 @@ package j2html.tags;
 
 import j2html.Config;
 import j2html.attributes.Attribute;
+import j2html.rendering.TagBuilder;
+import j2html.rendering.FlatHtml;
+import j2html.rendering.HtmlBuilder;
+import j2html.rendering.IndentedHtml;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -10,7 +14,7 @@ import java.util.stream.Stream;
 
 public class ContainerTag<T extends ContainerTag<T>> extends Tag<T> {
 
-    private List<DomContent> children;
+    protected List<DomContent> children;
 
     public ContainerTag(String tagName) {
         super(tagName);
@@ -143,100 +147,40 @@ public class ContainerTag<T extends ContainerTag<T>> extends Tag<T> {
      */
     public String renderFormatted() {
         try {
-            return renderFormatted(0);
-        } catch (IOException e) {
+            return render(IndentedHtml.into(new StringBuilder(), Config.global())).toString();
+        }catch (IOException e) {
             throw new RuntimeException(e.getMessage(), e);
         }
     }
 
-    private static void indent(Appendable appendable, int level) throws IOException {
-        appendable.append(Config.indenter.indent(level, ""));
-    }
-
-    private String renderFormatted(int lvl) throws IOException {
-        StringBuilder sb = new StringBuilder();
-        renderFormatted(lvl, sb);
-        return sb.toString();
-    }
-
-
-    private void renderFormatted(int lvl, Appendable sb) throws IOException {
-
-        renderOpenTag(sb, null);
-        if (hasTagName() && !isSelfFormattingTag()) {
-            sb.append("\n");
-        }
-        if (!children.isEmpty()) {
-            for (DomContent c : children) {
-                lvl++;
-                if (c instanceof ContainerTag) {
-                    if (((ContainerTag) c).hasTagName()) {
-                        if (this.isSelfFormattingTag()) {
-                            c.render(sb);
-                        } else {
-                            indent(sb, lvl);
-                            ((ContainerTag<?>) c).renderFormatted(lvl, sb);
-                        }
-                    } else {
-                        if (this.isSelfFormattingTag()) {
-                            c.render(sb);
-                        } else {
-                            ((ContainerTag<?>) c).renderFormatted(lvl-1, sb);
-                        }
-                    }
-                } else {
-                    if (!this.isSelfFormattingTag()) {
-                        indent(sb, lvl);
-                    }
-                    c.render(sb);
-                    if (!this.isSelfFormattingTag()) {
-                        sb.append("\n");
-                    }
-                }
-                lvl--;
-            }
-        }
-        if (hasTagName() && !this.isSelfFormattingTag()) {
-            indent(sb, lvl);
-        }
-        renderCloseTag(sb);
+    @Override
+    public <T extends Appendable> T render(HtmlBuilder<T> builder, Object model) throws IOException {
         if (hasTagName()) {
-            sb.append("\n");
+            TagBuilder tagBuilder = builder.appendStartTag(getTagName());
+            for(Attribute attribute : getAttributes()){
+                attribute.render(tagBuilder, model);
+            }
+            tagBuilder.completeTag();
         }
-    }
 
-    private boolean isSelfFormattingTag() {
-        return "textarea".equals(tagName) || "pre".equals(tagName);
-    }
+        for(DomContent child : children){
+            child.render(builder, model);
+        }
 
-    protected void renderOpenTag(Appendable writer, Object model) throws IOException {
-        if (!hasTagName()) { // avoid <null> and <> tags
-            return;
+        if(hasTagName()) {
+            builder.appendEndTag(getTagName());
         }
-        writer.append("<").append(tagName);
-        for (Attribute attribute : getAttributes()) {
-            attribute.renderModel(writer, model);
-        }
-        writer.append(">");
-    }
 
-    protected void renderCloseTag(Appendable writer) throws IOException {
-        if (!hasTagName()) { // avoid <null> and <> tags
-            return;
-        }
-        writer.append("</");
-        writer.append(tagName);
-        writer.append(">");
+        return builder.output();
     }
 
     @Override
+    @Deprecated
     public void renderModel(Appendable writer, Object model) throws IOException {
-        renderOpenTag(writer, model);
-        if (children != null && !children.isEmpty()) {
-            for (DomContent child : children) {
-                child.renderModel(writer, model);
-            }
-        }
-        renderCloseTag(writer);
+        HtmlBuilder builder = (writer instanceof HtmlBuilder)
+            ? (HtmlBuilder) writer
+            : FlatHtml.into(writer, Config.global());
+
+        render(builder, model);
     }
 }

--- a/library/src/main/java/j2html/tags/ContainerTag.java
+++ b/library/src/main/java/j2html/tags/ContainerTag.java
@@ -154,7 +154,7 @@ public class ContainerTag<T extends ContainerTag<T>> extends Tag<T> {
     }
 
     @Override
-    public <T extends Appendable> T render(HtmlBuilder<T> builder, Object model) throws IOException {
+    public <A extends Appendable> A render(HtmlBuilder<A> builder, Object model) throws IOException {
         if (hasTagName()) {
             TagBuilder tagBuilder = builder.appendStartTag(getTagName());
             for(Attribute attribute : getAttributes()){

--- a/library/src/main/java/j2html/tags/EmptyTag.java
+++ b/library/src/main/java/j2html/tags/EmptyTag.java
@@ -33,8 +33,8 @@ public class EmptyTag<T extends EmptyTag<T>> extends Tag<T> {
     @Override
     @Deprecated
     public void renderModel(Appendable writer, Object model) throws IOException {
-        HtmlBuilder builder = (writer instanceof HtmlBuilder)
-            ? (HtmlBuilder) writer
+        HtmlBuilder<?> builder = (writer instanceof HtmlBuilder)
+            ? (HtmlBuilder<?>) writer
             : FlatHtml.into(writer, Config.global());
 
         render(builder, model);

--- a/library/src/main/java/j2html/tags/EmptyTag.java
+++ b/library/src/main/java/j2html/tags/EmptyTag.java
@@ -21,7 +21,7 @@ public class EmptyTag<T extends EmptyTag<T>> extends Tag<T> {
     }
 
     @Override
-    public <T extends Appendable> T render(HtmlBuilder<T> builder, Object model) throws IOException {
+    public <A extends Appendable> A render(HtmlBuilder<A> builder, Object model) throws IOException {
         TagBuilder attrs = builder.appendEmptyTag(getTagName());
         for (Attribute attr : getAttributes()) {
             attr.render(attrs, model);

--- a/library/src/main/java/j2html/tags/EmptyTag.java
+++ b/library/src/main/java/j2html/tags/EmptyTag.java
@@ -2,34 +2,41 @@ package j2html.tags;
 
 import j2html.Config;
 import j2html.attributes.Attribute;
+import j2html.rendering.TagBuilder;
+import j2html.rendering.FlatHtml;
+import j2html.rendering.HtmlBuilder;
+
 import java.io.IOException;
 
 public class EmptyTag<T extends EmptyTag<T>> extends Tag<T> {
 
     public EmptyTag(String tagName) {
         super(tagName);
-        if(tagName == null){
+        if (tagName == null) {
             throw new IllegalArgumentException("Illegal tag name: null");
         }
-        if("".equals(tagName)){
+        if ("".equals(tagName)) {
             throw new IllegalArgumentException("Illegal tag name: \"\"");
         }
     }
 
     @Override
-    public void render(Appendable writer) throws IOException {
-        renderModel(writer, null);
+    public <T extends Appendable> T render(HtmlBuilder<T> builder, Object model) throws IOException {
+        TagBuilder attrs = builder.appendEmptyTag(getTagName());
+        for (Attribute attr : getAttributes()) {
+            attr.render(attrs, model);
+        }
+        attrs.completeTag();
+        return builder.output();
     }
 
     @Override
+    @Deprecated
     public void renderModel(Appendable writer, Object model) throws IOException {
-        writer.append("<").append(tagName);
-        for (Attribute attribute : getAttributes()) {
-            attribute.renderModel(writer, model);
-        }
-        if (Config.closeEmptyTags) {
-            writer.append("/");
-        }
-        writer.append(">");
+        HtmlBuilder builder = (writer instanceof HtmlBuilder)
+            ? (HtmlBuilder) writer
+            : FlatHtml.into(writer, Config.global());
+
+        render(builder, model);
     }
 }

--- a/library/src/main/java/j2html/tags/Renderable.java
+++ b/library/src/main/java/j2html/tags/Renderable.java
@@ -1,21 +1,53 @@
 package j2html.tags;
 
+import j2html.Config;
+import j2html.rendering.FlatHtml;
+import j2html.rendering.HtmlBuilder;
+
 import java.io.IOException;
+import java.io.UncheckedIOException;
 
 public interface Renderable {
+
+    /**
+     * Render the Renderable and it's children using the supplied builder.
+     *
+     * @param builder A builder that can compose HTML elements.
+     * @param model   A model object to provide data for children to render.
+     * @param <T>     The type of the Appendable which HTML is being appended to.
+     * @return The Appendable to which HTML has been appended.
+     * @throws IOException
+     */
+    default <T extends Appendable> T render(HtmlBuilder<T> builder, Object model) throws IOException {
+        // This method should be overridden by any internal classes.
+        // renderModel() is only being called to support backwards
+        // compatibility.
+        renderModel(builder, model);
+        return builder.output();
+    }
+
+    /**
+     * Render the Renderable and it's children using the supplied builder.
+     *
+     * @param builder A builder that can compose HTML elements.
+     * @param <T>     The type of the Appendable to which HTML is being appended.
+     * @return The Appendable to which HTML has been appended.
+     * @throws IOException
+     */
+    default <T extends Appendable> T render(HtmlBuilder<T> builder) throws IOException {
+        return render(builder, null);
+    }
 
     /**
      * Create a StringBuilder and use it to render the Renderable and it's
      * children
      */
     default String render() {
-        StringBuilder stringBuilder = new StringBuilder();
         try {
-            render(stringBuilder);
+            return render(FlatHtml.into(new StringBuilder(), Config.global())).toString();
         } catch (IOException e) {
-            throw new RuntimeException(e.getMessage(), e);
+            throw new UncheckedIOException(e);
         }
-        return stringBuilder.toString();
     }
 
     /**
@@ -23,8 +55,13 @@ public interface Renderable {
      *
      * @param writer the current writer
      */
+    @Deprecated
     default void render(Appendable writer) throws IOException {
-        renderModel(writer, null);
+        if (writer instanceof HtmlBuilder) {
+            render((HtmlBuilder<? extends Appendable>) writer);
+        } else {
+            render(FlatHtml.into(writer, Config.global()));
+        }
     }
 
     /**
@@ -33,5 +70,12 @@ public interface Renderable {
      * @param writer the current writer
      * @param model  a model object to provide data for children to render
      */
-    void renderModel(Appendable writer, Object model) throws IOException;
+    @Deprecated
+    default void renderModel(Appendable writer, Object model) throws IOException {
+        // This method is a placeholder to support any client classes
+        // which previously extended Renderable implementers, such as Tags.
+        // No internal classes should implement this method; except to support
+        // compatibility.  Instead they should implement rendering with an HtmlBuilder.
+        throw new RuntimeException("Renderable.renderModel(Appendable writer, Object model) has been deprecated.  Please use Renderable.render(HtmlBuilder<T> builder, Object model) instead.");
+    }
 }

--- a/library/src/main/java/j2html/tags/Tag.java
+++ b/library/src/main/java/j2html/tags/Tag.java
@@ -2,7 +2,6 @@ package j2html.tags;
 
 import j2html.attributes.Attr;
 import j2html.attributes.Attribute;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 

--- a/library/src/main/java/j2html/tags/Text.java
+++ b/library/src/main/java/j2html/tags/Text.java
@@ -1,6 +1,9 @@
 package j2html.tags;
 
 import j2html.Config;
+import j2html.rendering.FlatHtml;
+import j2html.rendering.HtmlBuilder;
+
 import java.io.IOException;
 
 public class Text extends DomContent {
@@ -12,13 +15,19 @@ public class Text extends DomContent {
     }
 
     @Override
-    public void render(Appendable writer) throws IOException {
-        renderModel(writer, null);
+    public <T extends Appendable> T render(HtmlBuilder<T> builder, Object model) throws IOException {
+        builder.appendEscapedText(text);
+        return builder.output();
     }
 
     @Override
+    @Deprecated
     public void renderModel(Appendable writer, Object model) throws IOException {
-        writer.append(Config.textEscaper.escape(text));
+        HtmlBuilder builder = (writer instanceof HtmlBuilder)
+            ? (HtmlBuilder) writer
+            : FlatHtml.into(writer, Config.global());
+
+        render(builder, model);
     }
 
 }

--- a/library/src/main/java/j2html/tags/Text.java
+++ b/library/src/main/java/j2html/tags/Text.java
@@ -16,7 +16,7 @@ public class Text extends DomContent {
 
     @Override
     public <T extends Appendable> T render(HtmlBuilder<T> builder, Object model) throws IOException {
-        builder.appendEscapedText(text);
+        builder.appendEscapedText(String.valueOf(text));
         return builder.output();
     }
 

--- a/library/src/main/java/j2html/tags/Text.java
+++ b/library/src/main/java/j2html/tags/Text.java
@@ -23,8 +23,8 @@ public class Text extends DomContent {
     @Override
     @Deprecated
     public void renderModel(Appendable writer, Object model) throws IOException {
-        HtmlBuilder builder = (writer instanceof HtmlBuilder)
-            ? (HtmlBuilder) writer
+        HtmlBuilder<?> builder = (writer instanceof HtmlBuilder)
+            ? (HtmlBuilder<?>) writer
             : FlatHtml.into(writer, Config.global());
 
         render(builder, model);

--- a/library/src/main/java/j2html/tags/UnescapedText.java
+++ b/library/src/main/java/j2html/tags/UnescapedText.java
@@ -1,5 +1,9 @@
 package j2html.tags;
 
+import j2html.Config;
+import j2html.rendering.FlatHtml;
+import j2html.rendering.HtmlBuilder;
+
 import java.io.IOException;
 
 public class UnescapedText extends DomContent {
@@ -11,13 +15,19 @@ public class UnescapedText extends DomContent {
     }
 
     @Override
-    public void render(Appendable writer) throws IOException {
-        renderModel(writer, null);
+    public <T extends Appendable> T render(HtmlBuilder<T> builder, Object model) throws IOException {
+        builder.appendUnescapedText(text);
+        return builder.output();
     }
 
     @Override
+    @Deprecated
     public void renderModel(Appendable writer, Object model) throws IOException {
-        writer.append(text);
+        HtmlBuilder builder = (writer instanceof HtmlBuilder)
+            ? (HtmlBuilder) writer
+            : FlatHtml.into(writer, Config.global());
+
+        render(builder, model);
     }
 
 }

--- a/library/src/main/java/j2html/tags/UnescapedText.java
+++ b/library/src/main/java/j2html/tags/UnescapedText.java
@@ -16,7 +16,7 @@ public class UnescapedText extends DomContent {
 
     @Override
     public <T extends Appendable> T render(HtmlBuilder<T> builder, Object model) throws IOException {
-        builder.appendUnescapedText(text);
+        builder.appendUnescapedText(String.valueOf(text));
         return builder.output();
     }
 

--- a/library/src/main/java/j2html/tags/UnescapedText.java
+++ b/library/src/main/java/j2html/tags/UnescapedText.java
@@ -23,8 +23,8 @@ public class UnescapedText extends DomContent {
     @Override
     @Deprecated
     public void renderModel(Appendable writer, Object model) throws IOException {
-        HtmlBuilder builder = (writer instanceof HtmlBuilder)
-            ? (HtmlBuilder) writer
+        HtmlBuilder<?> builder = (writer instanceof HtmlBuilder)
+            ? (HtmlBuilder<?>) writer
             : FlatHtml.into(writer, Config.global());
 
         render(builder, model);

--- a/library/src/test/java/j2html/model/Template.java
+++ b/library/src/test/java/j2html/model/Template.java
@@ -1,5 +1,6 @@
 package j2html.model;
 
+import j2html.rendering.HtmlBuilder;
 import j2html.tags.DomContent;
 import java.io.IOException;
 
@@ -12,4 +13,10 @@ public abstract class Template<T> extends DomContent {
     }
 
     public abstract void renderTemplate(Appendable writer, T model) throws IOException;
+
+    @Override
+    public <T extends Appendable> T render(HtmlBuilder<T> builder, Object model) throws IOException{
+        renderModel(builder.output(), model);
+        return builder.output();
+    }
 }

--- a/library/src/test/java/j2html/rendering/FlatHtmlTest.java
+++ b/library/src/test/java/j2html/rendering/FlatHtmlTest.java
@@ -1,0 +1,86 @@
+package j2html.rendering;
+
+import j2html.Config;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static j2html.TagCreator.div;
+import static j2html.TagCreator.input;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class FlatHtmlTest {
+
+    @Test
+    public void start_tags_contain_attributes() throws IOException {
+        assertThat(
+            FlatHtml.inMemory().appendStartTag("abc")
+                .appendAttribute("x", "X")
+                .appendBooleanAttribute("y")
+            .completeTag().output().toString(),
+            is("<abc x=\"X\" y>")
+        );
+    }
+
+    @Test
+    public void empty_tags_contain_attributes() throws IOException {
+        assertThat(
+            FlatHtml.inMemory().appendEmptyTag("abc")
+                .appendAttribute("x", "X")
+                .appendBooleanAttribute("y")
+                .completeTag().output().toString(),
+            is("<abc x=\"X\" y>")
+        );
+    }
+
+    @Test
+    public void unescaped_text_is_not_modified() throws Exception {
+        assertThat(
+            FlatHtml.inMemory().appendUnescapedText("<>&\"\'").output().toString(),
+            is("<>&\"\'")
+        );
+    }
+
+    @Test
+    public void escaped_text_replaces_special_characters_with_character_entities() throws Exception {
+        assertThat(
+            FlatHtml.inMemory().appendEscapedText("<>&\"\'").output().toString(),
+            is("&lt;&gt;&amp;&quot;&#x27;")
+        );
+    }
+
+    @Test
+    public void attribute_values_are_escaped() throws IOException {
+        assertThat(
+            div().withId("<>&\"\'").render(FlatHtml.inMemory()).toString(),
+            is("<div id=\"&lt;&gt;&amp;&quot;&#x27;\"></div>")
+        );
+    }
+
+    @Test
+    public void empty_tags_are_closed_when_configured() throws IOException {
+        assertThat(
+            input().render(FlatHtml.inMemory(Config.defaults().withEmptyTagsClosed(false))).toString(),
+            is("<input>")
+        );
+
+        assertThat(
+            input().render(FlatHtml.inMemory(Config.defaults().withEmptyTagsClosed(true))).toString(),
+            is("<input/>")
+        );
+    }
+
+    @Test
+    public void end_tags_are_never_closed() throws IOException {
+        assertThat(
+            div().render(FlatHtml.inMemory(Config.defaults().withEmptyTagsClosed(false))).toString(),
+            is("<div></div>")
+        );
+
+        assertThat(
+            div().render(FlatHtml.inMemory(Config.defaults().withEmptyTagsClosed(true))).toString(),
+            is("<div></div>")
+        );
+    }
+}

--- a/library/src/test/java/j2html/rendering/IndentedHtmlTest.java
+++ b/library/src/test/java/j2html/rendering/IndentedHtmlTest.java
@@ -1,0 +1,194 @@
+package j2html.rendering;
+
+import j2html.Config;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static j2html.TagCreator.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class IndentedHtmlTest {
+
+    @Test
+    public void unescaped_text_is_not_modified() throws Exception {
+        assertThat(
+            IndentedHtml.inMemory().appendUnescapedText("<>&\"\'").output().toString(),
+            is("<>&\"\'\n")
+        );
+    }
+
+    @Test
+    public void escaped_text_replaces_special_characters_with_character_entities() throws Exception {
+        assertThat(
+            IndentedHtml.inMemory().appendEscapedText("<>&\"\'").output().toString(),
+            is("&lt;&gt;&amp;&quot;&#x27;\n")
+        );
+    }
+
+    @Test
+    public void root_elements_are_not_indented() throws IOException {
+        assertThat(
+            div().render(IndentedHtml.inMemory()).toString(),
+            is("<div>\n</div>\n")
+        );
+
+        assertThat(
+            input().render(IndentedHtml.inMemory()).toString(),
+            is("<input>\n")
+        );
+    }
+
+    @Test
+    public void indentation_increases_for_each_layer_of_children() throws IOException {
+        assertThat(
+            div(div(div(input()))).render(IndentedHtml.inMemory()).toString(),
+            is(
+                "<div>\n" +
+                    "    <div>\n" +
+                    "        <div>\n" +
+                    "            <input>\n" +
+                    "        </div>\n" +
+                    "    </div>\n" +
+                    "</div>\n"
+            )
+        );
+    }
+
+    @Test
+    public void lines_of_text_are_indented_as_siblings() throws IOException {
+        assertThat(
+            div("abc\ndef\nghi").render(IndentedHtml.inMemory()).toString(),
+            is(
+                "<div>\n" +
+                    "    abc\n" +
+                    "    def\n" +
+                    "    ghi\n" +
+                    "</div>\n"
+            )
+        );
+    }
+
+    @Test
+    public void indentation_remains_the_same_for_sibling() throws IOException {
+        assertThat(
+            div(div(), input(), text("abc\ndef"), div()).render(IndentedHtml.inMemory()).toString(),
+            is(
+                "<div>\n" +
+                    "    <div>\n" +
+                    "    </div>\n" +
+                    "    <input>\n" +
+                    "    abc\n" +
+                    "    def\n" +
+                    "    <div>\n" +
+                    "    </div>\n" +
+                    "</div>\n"
+            )
+        );
+    }
+
+    @Test
+    public void attributes_are_defined_within_the_start_tag_on_a_single_line() throws IOException {
+        assertThat(
+            div(
+                div(
+                    div(
+                        input().withId("D").withClass("xyz")
+                    ).withId("C")
+                ).withId("B")
+            ).withId("A").render(IndentedHtml.inMemory()).toString(),
+            is(
+                "<div id=\"A\">\n" +
+                    "    <div id=\"B\">\n" +
+                    "        <div id=\"C\">\n" +
+                    "            <input id=\"D\" class=\"xyz\">\n" +
+                    "        </div>\n" +
+                    "    </div>\n" +
+                    "</div>\n"
+            )
+        );
+    }
+
+    @Test
+    public void attribute_values_are_escaped() throws IOException {
+        assertThat(
+            div().withId("<>&\"\'").render(IndentedHtml.inMemory()).toString(),
+            is("<div id=\"&lt;&gt;&amp;&quot;&#x27;\">\n</div>\n")
+        );
+    }
+
+    @Test
+    public void content_within_pre_elements_is_not_indented() throws IOException {
+        //Single line text.
+        assertThat(
+            div(pre("abc")).render(IndentedHtml.inMemory()).toString(),
+            is(
+                "<div>\n" +
+                    "    <pre>abc</pre>\n" +
+                    "</div>\n"
+            )
+        );
+
+        //Multiline text.
+        assertThat(
+            div(pre("abc\ndef")).render(IndentedHtml.inMemory()).toString(),
+            is(
+                "<div>\n" +
+                    "    <pre>abc\ndef</pre>\n" +
+                    "</div>\n"
+            )
+        );
+
+        //Child elements.
+        assertThat(
+            div(pre(code("abc\ndef"))).render(IndentedHtml.inMemory()).toString(),
+            is(
+                "<div>\n" +
+                    "    <pre><code>abc\ndef</code></pre>\n" +
+                    "</div>\n"
+            )
+        );
+    }
+
+    @Test
+    public void content_within_textarea_elements_is_not_indented() throws IOException {
+        //Single line text.
+        assertThat(
+            textarea("abc").render(IndentedHtml.inMemory()).toString(),
+            is("<textarea>abc</textarea>\n")
+        );
+
+        //Multiline text.
+        assertThat(
+            textarea("abc\ndef").render(IndentedHtml.inMemory()).toString(),
+            is("<textarea>abc\ndef</textarea>\n")
+        );
+    }
+
+    @Test
+    public void empty_tags_are_closed_when_configured() throws IOException {
+        assertThat(
+            input().render(IndentedHtml.inMemory(Config.defaults().withEmptyTagsClosed(false))).toString(),
+            is("<input>\n")
+        );
+
+        assertThat(
+            input().render(IndentedHtml.inMemory(Config.defaults().withEmptyTagsClosed(true))).toString(),
+            is("<input/>\n")
+        );
+    }
+
+    @Test
+    public void end_tags_are_never_closed() throws IOException {
+        assertThat(
+            div().render(IndentedHtml.inMemory(Config.defaults().withEmptyTagsClosed(false))).toString(),
+            is("<div>\n</div>\n")
+        );
+
+        assertThat(
+            div().render(IndentedHtml.inMemory(Config.defaults().withEmptyTagsClosed(true))).toString(),
+            is("<div>\n</div>\n")
+        );
+    }
+}

--- a/library/src/test/java/j2html/rendering/RenderingCompatabilityTest.java
+++ b/library/src/test/java/j2html/rendering/RenderingCompatabilityTest.java
@@ -1,0 +1,116 @@
+package j2html.rendering;
+
+import j2html.attributes.Attribute;
+import j2html.tags.DomContent;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static j2html.TagCreator.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class RenderingCompatabilityTest {
+
+    @Test
+    public void container_tags_continue_to_support_original_model_rendering_methods() throws IOException {
+        StringBuilder stringBuilder = new StringBuilder();
+        div(div()).renderModel(stringBuilder, null);
+        assertThat(stringBuilder.toString(), is("<div><div></div></div>"));
+    }
+
+    @Test
+    public void empty_tags_continue_to_support_original_model_rendering_methods() throws IOException {
+        StringBuilder stringBuilder = new StringBuilder();
+        input().withId("X").renderModel(stringBuilder, null);
+        assertThat(stringBuilder.toString(), is("<input id=\"X\">"));
+    }
+
+    @Test
+    public void text_continues_to_support_original_model_rendering_methods() throws IOException {
+        StringBuilder stringBuilder = new StringBuilder();
+        text("abc").renderModel(stringBuilder, null);
+        assertThat(stringBuilder.toString(), is("abc"));
+    }
+
+    @Test
+    public void unescaped_text_continues_to_support_original_model_rendering_methods() throws IOException {
+        StringBuilder stringBuilder = new StringBuilder();
+        rawHtml("abc").renderModel(stringBuilder, null);
+        assertThat(stringBuilder.toString(), is("abc"));
+    }
+
+    @Test
+    public void client_classes_which_implement_dom_rendering_continue_to_work_with_html_builder() throws IOException {
+        // Simulate a client class which can be injected into ContainerTags as
+        // regular DomContent.  Those client classes should continue to work
+        // even though HtmlBuilders are the newer approach to rendering.
+        DomContent dom = div(
+            new DomContent() {
+                @Override
+                public void renderModel(Appendable writer, Object model) throws IOException {
+                    writer.append(String.valueOf(model));
+                }
+            }
+        );
+
+        // Default rendering assumes a null model. Ensure that
+        // convenience methods continue to work.
+        assertThat(dom.render(), is("<div>null</div>"));
+
+        StringBuilder stringBuilder = new StringBuilder();
+        dom.render(stringBuilder);
+        assertThat(stringBuilder.toString(), is("<div>null</div>"));
+
+        stringBuilder = new StringBuilder();
+        dom.renderModel(stringBuilder, "victory");
+        assertThat(stringBuilder.toString(), is("<div>victory</div>"));
+
+        // Rendering with an HtmlBuilder defers to the original methods.
+        assertThat(
+            dom.render(FlatHtml.inMemory(), "success").toString(),
+            is("<div>success</div>")
+        );
+    }
+
+    @Test
+    public void client_classes_which_implement_attribute_rendering_continue_to_work_with_Attribute_builder() throws IOException {
+        Attribute mock = new MockAttribute("XXX", "fail");
+
+        // Stand-alone rendering.
+        assertThat(mock.render(), is(" mock=\"null\""));
+
+        StringBuilder stringBuilder = new StringBuilder();
+        mock.render(stringBuilder);
+        assertThat(stringBuilder.toString(), is(" mock=\"null\""));
+
+        assertThat(
+            mock.render(FlatHtml.inMemory(), "success").toString(),
+            is(" mock=\"success\"")
+        );
+
+        // In empty tags.
+        assertThat(
+            input().attr(mock).render(FlatHtml.inMemory(), "success").toString(),
+            is("<input mock=\"success\">")
+        );
+
+        // In container tags.
+        assertThat(
+            div().attr(mock).render(FlatHtml.inMemory(), "success").toString(),
+            is("<div mock=\"success\"></div>")
+        );
+    }
+
+    private final class MockAttribute extends Attribute {
+
+        public MockAttribute(String name, String value) {
+            super(name, value);
+        }
+
+        @Override
+        public void renderModel(Appendable writer, Object model) throws IOException {
+            writer.append(" mock=\"").append(String.valueOf(model)).append("\"");
+        }
+    }
+}

--- a/library/src/test/java/j2html/tags/TagCreatorTest.java
+++ b/library/src/test/java/j2html/tags/TagCreatorTest.java
@@ -24,6 +24,8 @@ public class TagCreatorTest {
 
     @Before
     public void setUp() {
+        Config.closeEmptyTags = false;
+
         employeeMap.put(1, new Employee(1, "Name 1", "Title 1"));
         employeeMap.put(2, new Employee(2, "Name 2", "Title 2"));
         employeeMap.put(3, new Employee(3, "Name 3", "Title 3"));

--- a/library/src/test/java/j2html/tags/TextTest.java
+++ b/library/src/test/java/j2html/tags/TextTest.java
@@ -1,0 +1,27 @@
+package j2html.tags;
+
+import j2html.rendering.FlatHtml;
+import j2html.rendering.IndentedHtml;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static j2html.TagCreator.rawHtml;
+import static j2html.TagCreator.text;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class TextTest {
+
+    @Test
+    public void null_text_is_rendered_as_a_string_literal() throws IOException {
+        assertThat(text(null).render(FlatHtml.inMemory()).toString(), is("null"));
+        assertThat(text(null).render(IndentedHtml.inMemory()).toString(), is("null\n"));
+    }
+
+    @Test
+    public void null_unescaped_text_is_rendered_as_a_string_literal() throws IOException {
+        assertThat(rawHtml(null).render(FlatHtml.inMemory()).toString(), is("null"));
+        assertThat(rawHtml(null).render(IndentedHtml.inMemory()).toString(), is("null\n"));
+    }
+}


### PR DESCRIPTION
- Two HtmlBuilders are implemented, FlatHtml and IndentedHtml.  Each offers the equivalent output as ContainerTag.render() and ContainerTag.renderFormatted.
- Existing implementations of DomContent/Renderable were updated to support HtmlBuilder where possible.
- Attribute was altered to support the use of TagBuilder.
- Config was altered to allow instances to be created, which can be passed into factory methods for the HtmlBuilders. Config.defaults() can be used for library defaults, while Config.global() can be used for current static configuration.
- Retained compatibility with previous library version as much as possible. See RenderingCompatabilityTest.