### PR TITLE
Adding Automatic-Module-Name to manifest to support JDK 9+.

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -129,6 +129,9 @@
                         <manifest>
                             <addClasspath>true</addClasspath>
                         </manifest>
+                        <manifestEntries>
+                            <Automatic-Module-Name>j2html</Automatic-Module-Name>
+                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -130,7 +130,7 @@
                             <addClasspath>true</addClasspath>
                         </manifest>
                         <manifestEntries>
-                            <Automatic-Module-Name>j2html</Automatic-Module-Name>
+                            <Automatic-Module-Name>com.j2html</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                 </configuration>


### PR DESCRIPTION
Using project-name (j2html) convention for module, which also matches package naming. There are a lot of recommendations towards using the reverse-DNS (com.j2html) naming convention.  But that does not match our current package naming, and may force a breaking change later.  Another consideration is that other projects like Spring and Hibernate seem to be fine with project-naming.

@tipsy , @obecker do you have any concerns with this approach?